### PR TITLE
Use correct chainId for Arbitrum

### DIFF
--- a/packages/front-end/src/App.tsx
+++ b/packages/front-end/src/App.tsx
@@ -64,7 +64,7 @@ const onboard = init({
       rpcUrl: RPC_URL_MAP[CHAINID.ARBITRUM_RINKEBY],
     },
     {
-      id: "0x3",
+      id: "0xa4b1",
       token: "ETH",
       namespace: "evm",
       label: "Arbitrum Mainnet",


### PR DESCRIPTION
# Task:

## Description

It seems like the only problem was that we were not using the correct id while setting up `web3-onboard`. This worked fine with MetaMask as it is an injected wallet and probably doesn't rely on it, while it seems like it's actually used in the `WalletConnect` flow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [x] If appropriate, I have properly tested my new functionality
