### PR TITLE
Fix Yield y-axis domain 

### DIFF
--- a/packages/front-end/src/components/VaultChart.tsx
+++ b/packages/front-end/src/components/VaultChart.tsx
@@ -80,6 +80,7 @@ export const VaultChart = () => {
 
               return {
                 epoch: ppsEpoch.id,
+                // @reminder: For presentation it's ok but reminder that number of float decimals is 17
                 growthSinceFirstEpoch: parseFloat(
                   ppsEpoch.growthSinceFirstEpoch
                 ),

--- a/packages/front-end/src/components/VaultChart.tsx
+++ b/packages/front-end/src/components/VaultChart.tsx
@@ -80,7 +80,9 @@ export const VaultChart = () => {
 
               return {
                 epoch: ppsEpoch.id,
-                growthSinceFirstEpoch: ppsEpoch.growthSinceFirstEpoch,
+                growthSinceFirstEpoch: parseFloat(
+                  ppsEpoch.growthSinceFirstEpoch
+                ),
                 timestamp: ppsEpoch.timestamp,
                 dateLocale,
               };


### PR DESCRIPTION
# Task:

## Description

If the numbers are strings `Rechart` can't figure out the min and max of _y-axis_ so the curve ends up going out of screen (for negative numbers in this case). Fix is to `parseFloat(growthSinceFirstEpoch)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
