### PR TITLE
Fix issue with Yield timestamp order

### DIFF
--- a/packages/front-end/src/components/VaultChart.tsx
+++ b/packages/front-end/src/components/VaultChart.tsx
@@ -68,30 +68,30 @@ export const VaultChart = () => {
     `,
     {
       onCompleted: (data) => {
-        const refinedData: any = data?.pricePerShares
-          ? data.pricePerShares.map((ppsEpoch: any) => {
-              const dateLocale = new Date(
-                parseInt(ppsEpoch.timestamp) * 1000
-              ).toLocaleString("default", {
-                month: "numeric",
-                day: "numeric",
-                year: "numeric",
-              });
+        const refinedData: any =
+          data?.pricePerShares?.length > 0
+            ? new Array(data.pricePerShares.length)
+            : [];
 
-              return {
-                epoch: ppsEpoch.id,
-                // @reminder: For presentation it's ok but reminder that number of float decimals is 17
-                growthSinceFirstEpoch: parseFloat(
-                  ppsEpoch.growthSinceFirstEpoch
-                ),
-                timestamp: ppsEpoch.timestamp,
-                dateLocale,
-              };
-            })
-          : [];
+        data.pricePerShares.map((ppsEpoch: any) => {
+          const dateLocale = new Date(
+            parseInt(ppsEpoch.timestamp) * 1000
+          ).toLocaleString("default", {
+            month: "numeric",
+            day: "numeric",
+            year: "numeric",
+          });
 
-        Object.keys(refinedData).length > 0 &&
-          setPricePerShares(Object.values(refinedData));
+          refinedData[+ppsEpoch.id - 1] = {
+            epoch: ppsEpoch.id,
+            // @reminder: For presentation it's ok but reminder that number of float decimals is 17
+            growthSinceFirstEpoch: parseFloat(ppsEpoch.growthSinceFirstEpoch),
+            timestamp: ppsEpoch.timestamp,
+            dateLocale,
+          };
+        });
+
+        setPricePerShares(refinedData);
       },
       onError: (err) => {
         console.log(err);


### PR DESCRIPTION
# Task:

## Description

Issue is that using the `.map` return doesn't guarantee order.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
