### PR TITLE
Use correct epoch for Cumulative Yield

### DIFF
--- a/packages/front-end/src/components/VaultStats.tsx
+++ b/packages/front-end/src/components/VaultStats.tsx
@@ -14,7 +14,7 @@ export const VaultStats = () => {
   useQuery(
     gql`
       query {
-        pricePerShares(orderBy: "id", orderDirection: "desc", first: 1) {
+        pricePerShares(orderBy: "timestamp", orderDirection: "desc", first: 1) {
           id
           epoch
           value


### PR DESCRIPTION
# Task:

## Description

Use `timestamp` instead of `id` as first is `BigInt` and second is Scalar ID on The Graph side (which is treated as a string).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
