### PR TITLE
refactor: move issuance and netdhv logic to catalogue

### DIFF
--- a/packages/contracts/contracts/AlphaOptionHandler.sol
+++ b/packages/contracts/contracts/AlphaOptionHandler.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 import "./Protocol.sol";
 import "./PriceFeed.sol";
+import "./OptionCatalogue.sol";
 
 import "./tokens/ERC20.sol";
 import "./libraries/Types.sol";
@@ -49,6 +50,9 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 	uint256 public orderIdCounter;
 	// custom option orders
 	mapping(uint256 => Types.Order) public orderStores;
+	/// @notice option catalogue
+	OptionCatalogue public catalogue;
+
 
 	/////////////////////////////////////
 	/// governance settable variables ///
@@ -95,6 +99,11 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 		_onlyGovernor();
 		require(_feeRecipient != address(0));
 		feeRecipient = _feeRecipient;
+	}
+
+	function setOptionCatalogue(address _catalogue) external {
+		_onlyGovernor();
+		catalogue = OptionCatalogue(_catalogue);
 	}
 
 	//////////////////////////////////////////////////////

--- a/packages/contracts/contracts/AlphaOptionHandler.sol
+++ b/packages/contracts/contracts/AlphaOptionHandler.sol
@@ -80,7 +80,8 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 	constructor(
 		address _authority,
 		address _protocol,
-		address _liquidityPool
+		address _liquidityPool,
+		address _catalogue
 	) AccessControl(IAuthority(_authority)) {
 		protocol = Protocol(_protocol);
 		liquidityPool = ILiquidityPool(_liquidityPool);
@@ -88,6 +89,7 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 		underlyingAsset = liquidityPool.underlyingAsset();
 		strikeAsset = liquidityPool.strikeAsset();
 		feeRecipient = _liquidityPool;
+		catalogue = OptionCatalogue(_catalogue);
 	}
 
 	function setFeePerContract(uint256 _feePerContract) external {
@@ -284,6 +286,7 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 			strikeAsset,
 			collateralAsset
 		);
+		catalogue.updateNetDhvExposureWithOptionSeries(seriesToStore, -int256(order.amount));
 		getPortfolioValuesFeed().updateStores(
 			seriesToStore,
 			int256(order.amount),
@@ -355,6 +358,7 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 			strikeAsset,
 			collateralAsset
 		);
+		catalogue.updateNetDhvExposureWithOptionSeries(seriesToStore, int256(order.amount));
 		getPortfolioValuesFeed().updateStores(
 			seriesToStore,
 			-int256(order.amount),

--- a/packages/contracts/contracts/AlphaOptionHandler.sol
+++ b/packages/contracts/contracts/AlphaOptionHandler.sol
@@ -53,7 +53,6 @@ contract AlphaOptionHandler is AccessControl, ReentrancyGuard {
 	/// @notice option catalogue
 	OptionCatalogue public catalogue;
 
-
 	/////////////////////////////////////
 	/// governance settable variables ///
 	/////////////////////////////////////

--- a/packages/contracts/contracts/BeyondPricer.sol
+++ b/packages/contracts/contracts/BeyondPricer.sol
@@ -192,10 +192,6 @@ contract BeyondPricer is AccessControl, ReentrancyGuard {
 		putSlippageGradientMultipliers = _putSlippageGradientMultipliers;
 	}
 
-	//////////////////////////////////////////////////////
-	/// access-controlled state changing functionality ///
-	//////////////////////////////////////////////////////
-
 	///////////////////////
 	/// complex getters ///
 	///////////////////////

--- a/packages/contracts/contracts/BeyondPricer.sol
+++ b/packages/contracts/contracts/BeyondPricer.sol
@@ -118,7 +118,7 @@ contract BeyondPricer is AccessControl, ReentrancyGuard {
 	}
 
 	function setSlippageGradient(uint256 _slippageGradient) external {
-		_onlyGuardian();
+		_onlyGovernor();
 		slippageGradient = _slippageGradient;
 	}
 
@@ -128,7 +128,7 @@ contract BeyondPricer is AccessControl, ReentrancyGuard {
 		uint256[] memory _callSlippageGradientMultipliers,
 		uint256[] memory _putSlippageGradientMultipliers
 	) external {
-		_onlyGuardian();
+		_onlyGovernor();
 		deltaBandWidth = _deltaBandWidth;
 		setSlippageGradientMultipliers(_callSlippageGradientMultipliers, _putSlippageGradientMultipliers);
 	}
@@ -137,7 +137,7 @@ contract BeyondPricer is AccessControl, ReentrancyGuard {
 		uint256[] memory _callSlippageGradientMultipliers,
 		uint256[] memory _putSlippageGradientMultipliers
 	) public {
-		_onlyGuardian();
+		_onlyGovernor();
 		if (
 			_callSlippageGradientMultipliers.length != 100e18 / deltaBandWidth ||
 			_putSlippageGradientMultipliers.length != 100e18 / deltaBandWidth

--- a/packages/contracts/contracts/OptionCatalogue.sol
+++ b/packages/contracts/contracts/OptionCatalogue.sol
@@ -8,12 +8,13 @@ import "./libraries/AccessControl.sol";
 import "./libraries/OptionsCompute.sol";
 
 import "prb-math/contracts/PRBMathSD59x18.sol";
+
 /**
  *  @title OptionCatalogue
  *  @dev Store information on options approved for sale and to buy as well as netDhvExposure of the option
  */
 contract OptionCatalogue is AccessControl {
-    using PRBMathSD59x18 for int256;
+	using PRBMathSD59x18 for int256;
 	///////////////////////////
 	/// immutable variables ///
 	///////////////////////////
@@ -27,8 +28,8 @@ contract OptionCatalogue is AccessControl {
 
 	// storage of option information and approvals
 	mapping(bytes32 => OptionStores) public optionStores;
-    // maximum absolute netDhvExposure 
-    uint256 public maxNetDhvExposure;
+	// maximum absolute netDhvExposure
+	uint256 public maxNetDhvExposure;
 	// array of expirations currently supported (mainly for frontend use)
 	uint64[] public expirations;
 	// details of supported options first key is expiration then isPut then an array of strikes (mainly for frontend use)
@@ -62,7 +63,7 @@ contract OptionCatalogue is AccessControl {
 		bool isSellable;
 	}
 
-    error MaxNetDhvExposureExceeded();
+	error MaxNetDhvExposureExceeded();
 
 	event SeriesApproved(
 		uint64 expiration,
@@ -79,12 +80,16 @@ contract OptionCatalogue is AccessControl {
 		bool isBuyable,
 		bool isSellable
 	);
-    event UpdaterUpdated(address updater, bool auth);
-    event MaxNetDhvExposureUpdated(uint256 maxNetDhvExposure);
+	event UpdaterUpdated(address updater, bool auth);
+	event MaxNetDhvExposureUpdated(uint256 maxNetDhvExposure);
 
-	constructor(address _authority, address _collateralAsset, uint256 _maxNetDhvExposure) AccessControl(IAuthority(_authority)) {
+	constructor(
+		address _authority,
+		address _collateralAsset,
+		uint256 _maxNetDhvExposure
+	) AccessControl(IAuthority(_authority)) {
 		collateralAsset = _collateralAsset;
-        maxNetDhvExposure = _maxNetDhvExposure;
+		maxNetDhvExposure = _maxNetDhvExposure;
 	}
 
 	///////////////
@@ -100,17 +105,18 @@ contract OptionCatalogue is AccessControl {
 			revert CustomErrors.InvalidAddress();
 		}
 		updater[_updater] = _auth;
-        emit UpdaterUpdated(_updater, _auth);
+		emit UpdaterUpdated(_updater, _auth);
 	}
 
 	/**
 	 * @notice change the max net dhv exposure
 	 */
-    function setMaxNetDhvExposure(uint256 _maxNetDhvExposure) external {
-        _onlyGovernor();
-        maxNetDhvExposure = _maxNetDhvExposure;
-        emit MaxNetDhvExposureUpdated(_maxNetDhvExposure);
-    }
+	function setMaxNetDhvExposure(uint256 _maxNetDhvExposure) external {
+		_onlyGovernor();
+		maxNetDhvExposure = _maxNetDhvExposure;
+		emit MaxNetDhvExposureUpdated(_maxNetDhvExposure);
+	}
+
 	//////////////////////////////////////////////////////
 	/// access-controlled state changing functionality ///
 	//////////////////////////////////////////////////////
@@ -124,7 +130,7 @@ contract OptionCatalogue is AccessControl {
 	function updateNetDhvExposure(bytes32 oHash, int256 netDhvExposureChange) external {
 		_isUpdater();
 		netDhvExposure[oHash] += netDhvExposureChange;
-        if (uint256(netDhvExposure[oHash].abs()) > maxNetDhvExposure) revert MaxNetDhvExposureExceeded();
+		if (uint256(netDhvExposure[oHash].abs()) > maxNetDhvExposure) revert MaxNetDhvExposureExceeded();
 	}
 
 	/**
@@ -145,7 +151,7 @@ contract OptionCatalogue is AccessControl {
 		// get the hash of the option (how the option is stored on the books)
 		bytes32 oHash = keccak256(abi.encodePacked(optionSeries.expiration, strike, optionSeries.isPut));
 		netDhvExposure[oHash] += netDhvExposureChange;
-        if (uint256(netDhvExposure[oHash].abs()) > maxNetDhvExposure) revert MaxNetDhvExposureExceeded();
+		if (uint256(netDhvExposure[oHash].abs()) > maxNetDhvExposure) revert MaxNetDhvExposureExceeded();
 	}
 
 	/**

--- a/packages/contracts/contracts/OptionCatalogue.sol
+++ b/packages/contracts/contracts/OptionCatalogue.sol
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import "./tokens/ERC20.sol";
+import "./libraries/Types.sol";
+import "./libraries/CustomErrors.sol";
+import "./libraries/AccessControl.sol";
+import "./libraries/OptionsCompute.sol";
+
+/**
+ *  @title OptionCatalogue
+ *  @dev Store information on options approved for sale and to buy as well as netDhvExposure of the option
+ */
+contract OptionCatalogue is AccessControl {
+
+	///////////////////////////
+	/// immutable variables ///
+	///////////////////////////
+
+	// asset that is used for collateral asset
+	address public immutable collateralAsset;
+
+	/////////////////////////////////////
+	/// governance settable variables ///
+	/////////////////////////////////////
+
+	// storage of option information and approvals
+	mapping(bytes32 => OptionStores) public optionStores;
+    // net dhv exposure of the option
+    mapping(bytes32 => int256) public netDhvExposure;
+	// array of expirations currently supported (mainly for frontend use)
+	uint64[] public expirations;
+	// details of supported options first key is expiration then isPut then an array of strikes (mainly for frontend use)
+	mapping(uint256 => mapping(bool => uint128[])) public optionDetails;
+    // approved to update netDhvExposure
+    mapping(address => bool) public updator;
+
+	//////////////////////////
+	/// constant variables ///
+	//////////////////////////
+
+	// oToken decimals
+	uint8 private constant OPYN_DECIMALS = 8;
+	// scale otoken conversion decimals
+	uint8 private constant CONVERSION_DECIMALS = 18 - OPYN_DECIMALS;
+
+	/////////////////////////
+	/// structs && events ///
+	/////////////////////////
+
+	struct OptionStores{
+		bool approvedOption;
+		bool isBuyable;
+		bool isSellable;
+	}
+
+	event SeriesApproved(
+		uint64 expiration,
+		uint128 strike,
+		bool isPut,
+		bool isBuyable,
+		bool isSellable
+	);
+	event SeriesDisabled(uint64 expiration, uint128 strike, bool isPut);
+	event SeriesAltered(
+		uint64 expiration,
+		uint128 strike,
+		bool isPut,
+		bool isBuyable,
+		bool isSellable
+	);
+
+	constructor(
+		address _authority,
+        address _collateralAsset
+	) AccessControl(IAuthority(_authority)) {
+		collateralAsset = _collateralAsset;
+	}
+
+	///////////////
+	/// setters ///
+	///////////////
+
+	/**
+	 * @notice change the status of a updator
+	 */
+	function setUpdator(address _updator, bool _auth) external {
+		_onlyGovernor();
+		if (_updator == address(0)) {
+			revert CustomErrors.InvalidAddress();
+		}
+		updator[_updator] = _auth;
+	}
+
+	//////////////////////////////////////////////////////
+	/// access-controlled state changing functionality ///
+	//////////////////////////////////////////////////////
+
+	/**
+	 * @notice update the net dhv exposure
+	 * @param  oHash the hash of the option
+     * @param  netDhvExposureChange the amount to change netDhvExposure by
+	 * @dev    only callable by an approved updator
+	 */
+    function updateNetDhvExposure(bytes32 oHash, int256 netDhvExposureChange) external {
+        _isUpdator();
+        netDhvExposure[oHash] += netDhvExposureChange;
+    }
+
+	/**
+	 * @notice update the net dhv exposure
+	 * @param  optionSeries the option series represented
+     * @param  netDhvExposureChange the amount to change netDhvExposure by
+	 * @dev    only callable by an approved updator
+	 */
+    function updateNetDhvExposureWithOptionSeries(Types.OptionSeries memory o, int256 netDhvExposureChange) external {
+        _isUpdator();
+        // make sure the strike gets formatted properly
+		uint128 strike = uint128(
+			formatStrikePrice(o.strike, collateralAsset) * 10**(CONVERSION_DECIMALS)
+		);
+		// get the hash of the option (how the option is stored on the books)
+		bytes32 oHash = keccak256(abi.encodePacked(o.expiration, strike, o.isPut));
+        netDhvExposure[oHash] += netDhvExposureChange;
+    }
+
+
+	/**
+	 * @notice issue an option series for buying or sale
+	 * @param  options option type to approve - strike in e18
+	 * @dev    only callable by the manager
+	 */
+	function issueNewSeries(Types.Option[] memory options) external {
+		_onlyManager();
+		uint256 addressLength = options.length;
+		for (uint256 i = 0; i < addressLength; i++) {
+			Types.Option memory o = options[i];
+			// make sure the strike gets formatted properly
+			uint128 strike = uint128(
+				formatStrikePrice(o.strike, collateralAsset) * 10**(CONVERSION_DECIMALS)
+			);
+			// get the hash of the option (how the option is stored on the books)
+			bytes32 optionHash = keccak256(abi.encodePacked(o.expiration, strike, o.isPut));
+			// if the option is already issued then skip it
+			if (optionStores[optionHash].approvedOption) {
+				continue;
+			}
+			// store information on the series
+			optionStores[optionHash] = OptionStores(
+				true, 				// approval
+				o.isBuyable,		
+				o.isSellable
+			);
+			// store it in an array, these are mainly for frontend/informational use
+			// if the strike array is empty for calls and puts for that expiry it means that this expiry hasnt been issued yet
+			// so we should save the expory
+			if (
+				optionDetails[o.expiration][true].length == 0 && optionDetails[o.expiration][false].length == 0
+			) {
+				expirations.push(o.expiration);
+			}
+			// we wouldnt get here if the strike already existed, so we store it in the array
+			// there shouldnt be any duplicates in the strike array or expiration array
+			optionDetails[o.expiration][o.isPut].push(strike);
+			// emit an event of the series creation, now users can write options on this series
+			emit SeriesApproved(o.expiration, strike, o.isPut, o.isBuyable, o.isSellable);
+		}
+	}
+
+	/**
+	 * @notice change whether an issued option is for buy or sale
+	 * @param  options option type to change status on - strike in e18
+	 * @dev    only callable by the manager
+	 */
+	function changeOptionBuyOrSell(Types.Option[] memory options) external {
+		_onlyManager();
+		uint256 adLength = options.length;
+		for (uint256 i = 0; i < adLength; i++) {
+			Types.Option memory o = options[i];
+			// make sure the strike gets formatted properly, we get it to e8 format in the converter
+			// then convert it back to e18
+			uint128 strike = uint128(
+				formatStrikePrice(o.strike, collateralAsset) * 10**(CONVERSION_DECIMALS)
+			);
+			// get the option hash
+			bytes32 optionHash = keccak256(abi.encodePacked(o.expiration, strike, o.isPut));
+			// if its already approved then we can change its parameters, if its not approved then revert as there is a mistake
+			if (optionStores[optionHash].approvedOption) {
+				optionStores[optionHash].isBuyable = o.isBuyable;
+				optionStores[optionHash].isSellable = o.isSellable;
+				emit SeriesAltered(o.expiration, strike, o.isPut, o.isBuyable, o.isSellable);
+			} else {
+				revert CustomErrors.UnapprovedSeries();
+			}
+		}
+	}
+
+	///////////////////////////
+	/// non-complex getters ///
+	///////////////////////////
+
+	/**
+	 * @notice get list of all expirations ever activated
+	 * @return list of expirations
+	 */
+	function getExpirations() external view returns (uint64[] memory) {
+		return expirations;
+	}
+	/**
+	 * @notice get list of all strikes for a specific expiration and flavour
+	 * @return list of strikes for a specific expiry and flavour
+	 */
+	function getOptionDetails(uint64 expiration, bool isPut) external view returns (uint128[] memory) {
+		return optionDetails[expiration][isPut];
+	}
+    function getOptionStores(bytes32 oHash) external view returns (OptionStores memory) {
+        return optionStores[oHash];
+    }
+	function isBuyable(bytes32 oHash) external view returns (bool) {
+		return optionStores[oHash].isBuyable;
+	}
+	function isSellable(bytes32 oHash) external view returns (bool) {
+		return optionStores[oHash].isSellable;
+	}
+	function approvedOptions(bytes32 oHash) external view returns (bool) {
+		return optionStores[oHash].approvedOption;
+	}
+
+	///////////////////////
+	/// complex getters ///
+	///////////////////////
+
+	/**
+	 * @notice Converts strike price to 1e8 format and floors least significant digits if needed
+	 * @param  strikePrice strikePrice in 1e18 format
+	 * @param  collateral address of collateral asset
+	 * @return if the transaction succeeded
+	 */
+	function formatStrikePrice(uint256 strikePrice, address collateral) public view returns (uint256) {
+		// convert strike to 1e8 format
+		uint256 price = strikePrice / (10**10);
+		uint256 collateralDecimals = ERC20(collateral).decimals();
+		if (collateralDecimals >= OPYN_DECIMALS) return price;
+		uint256 difference = OPYN_DECIMALS - collateralDecimals;
+		// round floor strike to prevent errors in Gamma protocol
+		return (price / (10**difference)) * (10**difference);
+	}
+
+	function _isUpdator() internal view {
+		if (!updator[msg.sender]) {
+			revert CustomErrors.NotUpdator();
+		}
+	}
+}

--- a/packages/contracts/contracts/OptionCatalogue.sol
+++ b/packages/contracts/contracts/OptionCatalogue.sol
@@ -42,7 +42,7 @@ contract OptionCatalogue is AccessControl {
 
 	// net dhv exposure of the option
 	mapping(bytes32 => int256) public netDhvExposure;
-    
+
 	//////////////////////////
 	/// constant variables ///
 	//////////////////////////
@@ -117,7 +117,7 @@ contract OptionCatalogue is AccessControl {
 
 	/**
 	 * @notice update the net dhv exposure
-	 * @param  oHash the hash of the option
+	 * @param  oHash the hash of the option - uses formatted strike
 	 * @param  netDhvExposureChange the amount to change netDhvExposure by
 	 * @dev    only callable by an approved updater
 	 */
@@ -129,7 +129,7 @@ contract OptionCatalogue is AccessControl {
 
 	/**
 	 * @notice update the net dhv exposure
-	 * @param  optionSeries the option series represented
+	 * @param  optionSeries the option series represented - assumes strike in e18
 	 * @param  netDhvExposureChange the amount to change netDhvExposure by
 	 * @dev    only callable by an approved updater
 	 */

--- a/packages/contracts/contracts/OptionCatalogue.sol
+++ b/packages/contracts/contracts/OptionCatalogue.sol
@@ -27,6 +27,8 @@ contract OptionCatalogue is AccessControl {
 	mapping(bytes32 => OptionStores) public optionStores;
 	// net dhv exposure of the option
 	mapping(bytes32 => int256) public netDhvExposure;
+    // maximum absolute netDhvExposure 
+    uint256 public maxNetDhvExposure;
 	// array of expirations currently supported (mainly for frontend use)
 	uint64[] public expirations;
 	// details of supported options first key is expiration then isPut then an array of strikes (mainly for frontend use)

--- a/packages/contracts/contracts/OptionExchange.sol
+++ b/packages/contracts/contracts/OptionExchange.sol
@@ -148,7 +148,8 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 		address _pricer,
 		address _addressbook,
 		address _swapRouter,
-		address _feeRecipient
+		address _feeRecipient,
+		address _catalogue
 	) AccessControl(IAuthority(_authority)) {
 		protocol = Protocol(_protocol);
 		liquidityPool = ILiquidityPool(_liquidityPool);
@@ -158,6 +159,7 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 		addressbook = AddressBookInterface(_addressbook);
 		swapRouter = ISwapRouter(_swapRouter);
 		pricer = BeyondPricer(_pricer);
+		catalogue = OptionCatalogue(_catalogue);
 		require(_feeRecipient != address(0));
 		feeRecipient = _feeRecipient;
 	}

--- a/packages/contracts/contracts/OptionExchange.sol
+++ b/packages/contracts/contracts/OptionExchange.sol
@@ -566,12 +566,12 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 		IOptionRegistry optionRegistry = getOptionRegistry();
 		SellParams memory sellParams;
 		bytes32 oHash;
-		(
-			sellParams.seriesAddress,
-			sellParams.seriesToStore,
-			sellParams.optionSeries,
-			oHash
-		) = _preChecks(_args.seriesAddress, _args.optionSeries, optionRegistry, true);
+		(sellParams.seriesAddress, sellParams.seriesToStore, sellParams.optionSeries, oHash) = _preChecks(
+			_args.seriesAddress,
+			_args.optionSeries,
+			optionRegistry,
+			true
+		);
 		// get the unit price for premium and delta
 		(sellParams.premium, sellParams.delta, sellParams.fee) = pricer.quoteOptionPrice(
 			sellParams.seriesToStore,
@@ -628,8 +628,11 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 		}
 		// this accounts for premium sent from buyback as well as any rounding errors from the dhv buyback
 		if (sellParams.premium > sellParams.premiumSent) {
-			// we need to make sure we arent eating into the withdraw partition with this trade 
-			if (ILiquidityPool(liquidityPool).getBalance(collateralAsset) < (sellParams.premium - sellParams.premiumSent)) {
+			// we need to make sure we arent eating into the withdraw partition with this trade
+			if (
+				ILiquidityPool(liquidityPool).getBalance(collateralAsset) <
+				(sellParams.premium - sellParams.premiumSent)
+			) {
 				revert CustomErrors.WithdrawExceedsLiquidity();
 			}
 			// take the funds from the liquidity pool and pay them here
@@ -691,6 +694,7 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 	function getPoolDenominatedValue() external view returns (uint256) {
 		return ERC20(collateralAsset).balanceOf(address(this));
 	}
+
 	//////////////////////////
 	/// internal utilities ///
 	//////////////////////////
@@ -855,7 +859,12 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 		SafeTransferLib.safeTransfer(ERC20(collateralAsset), address(liquidityPool), premium);
 	}
 
-	function _preChecks(address _seriesAddress, Types.OptionSeries memory _optionSeries, IOptionRegistry _optionRegistry, bool isSell)
+	function _preChecks(
+		address _seriesAddress,
+		Types.OptionSeries memory _optionSeries,
+		IOptionRegistry _optionRegistry,
+		bool isSell
+	)
 		internal
 		view
 		returns (
@@ -966,5 +975,4 @@ contract OptionExchange is Pausable, AccessControl, ReentrancyGuard, IHedgingRea
 	function hedgeDelta(int256 _delta) external returns (int256) {
 		revert();
 	}
-
 }

--- a/packages/contracts/contracts/libraries/CustomErrors.sol
+++ b/packages/contracts/contracts/libraries/CustomErrors.sol
@@ -5,6 +5,7 @@ interface CustomErrors {
 	error NotKeeper();
 	error IVNotFound();
 	error NotHandler();
+	error NotUpdator();
 	error VaultExpired();
 	error InvalidInput();
 	error InvalidPrice();

--- a/packages/contracts/contracts/libraries/CustomErrors.sol
+++ b/packages/contracts/contracts/libraries/CustomErrors.sol
@@ -5,7 +5,7 @@ interface CustomErrors {
 	error NotKeeper();
 	error IVNotFound();
 	error NotHandler();
-	error NotUpdator();
+	error NotUpdater();
 	error VaultExpired();
 	error InvalidInput();
 	error InvalidPrice();

--- a/packages/contracts/contracts/libraries/RyskActions.sol
+++ b/packages/contracts/contracts/libraries/RyskActions.sol
@@ -14,7 +14,6 @@ import "./Types.sol";
  * A2 can only parse arguments for issue actions
  * A3 can only parse arguments for buy option actions
  * A4 can only parse arguments for sell option or close option actions
- * A5 amount must be greater than or equal to 1e16 to avoid tiny positions in the dhv
  */
 library RyskActions {
     // possible actions that can be performed
@@ -88,7 +87,6 @@ library RyskActions {
      */
     function _parseBuyOptionArgs(ActionArgs memory _args) internal pure returns (BuyOptionArgs memory) {
         require(_args.actionType == ActionType.BuyOption, "A3");
-        require(_args.amount >= 1e16, "A5");
         return
             BuyOptionArgs({
                 optionSeries: _args.optionSeries,
@@ -106,7 +104,6 @@ library RyskActions {
      */
     function _parseSellOptionArgs(ActionArgs memory _args) internal pure returns (SellOptionArgs memory) {
         require(_args.actionType == ActionType.SellOption || _args.actionType == ActionType.CloseOption, "A4");
-        require(_args.amount >= 1e16, "A5");
         return
             SellOptionArgs({
                 optionSeries: _args.optionSeries,

--- a/packages/contracts/test/CreateOptionProducts.ts
+++ b/packages/contracts/test/CreateOptionProducts.ts
@@ -68,6 +68,7 @@ import { create } from "domain"
 import { NewWhitelist } from "../types/NewWhitelist"
 import { OptionExchange } from "../types/OptionExchange"
 import { OtokenFactory } from "../types/OtokenFactory"
+import { OptionCatalogue } from "../types/OptionCatalogue"
 let usd: MintableERC20
 let weth: WETH
 let wethERC20: MintableERC20
@@ -99,6 +100,7 @@ let oTokenUSDCXCLaterExp2: Otoken
 let collateralAllocatedToVault1: BigNumber
 let spotHedgingReactor: UniswapV3HedgingReactor
 let exchange: OptionExchange
+let catalogue: OptionCatalogue
 let pricer: BeyondPricer
 let authority: string
 
@@ -254,6 +256,7 @@ describe("Structured Product maker", async () => {
 		volatility = lpParams.volatility
 		liquidityPool = lpParams.liquidityPool
 		exchange = lpParams.exchange
+		catalogue = lpParams.catalogue
 		pricer = lpParams.pricer
 		signers = await hre.ethers.getSigners()
 		senderAddress = await signers[0].getAddress()
@@ -348,7 +351,7 @@ describe("Structured Product maker", async () => {
 		it("SETUP: approve series", async () => {
 			const priceQuote = await priceFeed.getNormalizedRate(weth.address, usd.address)
 			const strikePrice = priceQuote.add(toWei(strike))
-			await exchange.issueNewSeries([
+			await catalogue.issueNewSeries([
 				{
 					expiration: expiration,
 					isPut: CALL_FLAVOR,

--- a/packages/contracts/test/CreateOptionProducts.ts
+++ b/packages/contracts/test/CreateOptionProducts.ts
@@ -1588,7 +1588,7 @@ describe("Structured Product maker", async () => {
 					},
 					amount
 				)
-			).add(toUSDC("100"))			
+			).add(toUSDC("100"))
 			let lowerQuoteResponse = await pricer.quoteOptionPrice(lowerProposedSeries, amount, true, 0)
 			await compareQuotes(lowerQuoteResponse, liquidityPool, priceFeed, lowerProposedSeries, amount, true, exchange, optionRegistry, usd, pricer, toWei("0"))
 			let lowerQuote = lowerQuoteResponse[0].sub(lowerQuoteResponse[2])

--- a/packages/contracts/test/ExchangeActions.ts
+++ b/packages/contracts/test/ExchangeActions.ts
@@ -325,7 +325,7 @@ describe("Actions tests", async () => {
 				}])).to.be.revertedWith("OperatorNotApproved()")
 		})
 	})
-    describe("Opyn Open Vault Action checks", async () => {
+	describe("Opyn Open Vault Action checks", async () => {
 
 		it("SUCCEED: set operator", async () => {
 			await controller.setOperator(exchange.address, true)
@@ -703,7 +703,7 @@ describe("Actions tests", async () => {
 						index: 0,
 						data: "0x"
 					},
-				]
+					]
 				}])
 			const vaultId = await controller.getAccountVaultCounter(senderAddress)
 			const vaultDetails = await controller.getVaultWithDetails(senderAddress, vaultId)
@@ -755,7 +755,7 @@ describe("Actions tests", async () => {
 						index: 0,
 						data: "0x"
 					},
-				]
+					]
 				}])
 			const vaultId = await controller.getAccountVaultCounter(senderAddress)
 			const vaultDetails = await controller.getVaultWithDetails(senderAddress, vaultId)
@@ -807,7 +807,7 @@ describe("Actions tests", async () => {
 						index: 0,
 						data: "0x"
 					},
-				]
+					]
 				}])).to.be.revertedWith("TokenImbalance()")
 			await usd.approve(exchange.address, 0)
 		})
@@ -864,7 +864,7 @@ describe("Actions tests", async () => {
 						data: "0x"
 					},
 
-				]
+					]
 				}])
 			const vaultId = await controller.getAccountVaultCounter(senderAddress)
 			const vaultDetails = await controller.getVaultWithDetails(senderAddress, vaultId)
@@ -927,9 +927,9 @@ describe("Actions tests", async () => {
 						index: 0,
 						data: "0x"
 					},
-				]
+					]
 				}])).to.be.revertedWith("UnauthorisedSender()")
-				await usd.approve(exchange.address, 0)
+			await usd.approve(exchange.address, 0)
 		})
 		it("SUCCEED: OPYN mint short option with collateral deposited via exchange then deposits the long option from sender in vault 1", async () => {
 			const margin = toUSDC("1000")
@@ -973,22 +973,24 @@ describe("Actions tests", async () => {
 						optionSeries: emptySeries,
 						index: 0,
 						data: "0x"
-					}]},
-					{
-						operation: 0,
-						operationQueue:[
-					{
-						actionType: 3,
-						owner: senderAddress,
-						secondAddress: senderAddress,
-						asset: otoken,
-						vaultId: 1,
-						amount: tinyAmount,
-						optionSeries: emptySeries,
-						index: 0,
-						data: "0x"
-					}]},
-				])
+					}]
+				},
+				{
+					operation: 0,
+					operationQueue: [
+						{
+							actionType: 3,
+							owner: senderAddress,
+							secondAddress: senderAddress,
+							asset: otoken,
+							vaultId: 1,
+							amount: tinyAmount,
+							optionSeries: emptySeries,
+							index: 0,
+							data: "0x"
+						}]
+				},
+			])
 			const vaultId = await controller.getAccountVaultCounter(senderAddress)
 			const vaultDetails = await controller.getVaultWithDetails(senderAddress, vaultId)
 			expect(vaultId).to.equal(vaultIdCounter)
@@ -1043,24 +1045,26 @@ describe("Actions tests", async () => {
 						optionSeries: emptySeries,
 						index: 0,
 						data: "0x"
-					}]},
-					{
-						operation: 0,
-						operationQueue:[
-					{
-						actionType: 3,
-						owner: senderAddress,
-						secondAddress: exchange.address,
-						asset: otoken,
-						vaultId: 1,
-						amount: tinyAmount,
-						optionSeries: emptySeries,
-						index: 0,
-						data: "0x"
-					}]},
-				])).to.be.revertedWith("UnauthorisedSender()")
-				await usd.approve(exchange.address, 0)
-				await otokenERC.approve(MARGIN_POOL[chainId], 0)
+					}]
+				},
+				{
+					operation: 0,
+					operationQueue: [
+						{
+							actionType: 3,
+							owner: senderAddress,
+							secondAddress: exchange.address,
+							asset: otoken,
+							vaultId: 1,
+							amount: tinyAmount,
+							optionSeries: emptySeries,
+							index: 0,
+							data: "0x"
+						}]
+				},
+			])).to.be.revertedWith("UnauthorisedSender()")
+			await usd.approve(exchange.address, 0)
+			await otokenERC.approve(MARGIN_POOL[chainId], 0)
 		})
 		it("SUCCEED: OPYN mint short option with collateral deposited via exchange then deposits the long option from sender in vault 1 and withdraws to sender", async () => {
 			const margin = toUSDC("1000")
@@ -1104,33 +1108,35 @@ describe("Actions tests", async () => {
 						optionSeries: emptySeries,
 						index: 0,
 						data: "0x"
-					}]},
-					{
-						operation: 0,
-						operationQueue:[
-					{
-						actionType: 4,
-						owner: senderAddress,
-						secondAddress: senderAddress,
-						asset: otoken,
-						vaultId: 1,
-						amount: tinyAmount,
-						optionSeries: emptySeries,
-						index: 0,
-						data: "0x"
-					}]},
-				])
-				const vaultId = await controller.getAccountVaultCounter(senderAddress)
-				const vaultDetails = await controller.getVaultWithDetails(senderAddress, vaultId)
-				expect(vaultId).to.equal(vaultIdCounter)
-				expect((vaultDetails)[1]).to.equal(1)
-				expect(vaultDetails[0].collateralAmounts[0]).to.equal(margin)
-				expect(vaultDetails[0].shortAmounts[0]).to.equal(tinyAmount)
-				expect(vaultDetails[0].shortOtokens[0]).to.equal(otoken)
-				const vault1Details = await controller.getVaultWithDetails(senderAddress, 1)
-				expect(vault1Details[0].longAmounts[0]).to.equal(0)
-				expect(vault1Details[0].longOtokens[0]).to.equal(ZERO_ADDRESS)
-				vaultIdCounter++
+					}]
+				},
+				{
+					operation: 0,
+					operationQueue: [
+						{
+							actionType: 4,
+							owner: senderAddress,
+							secondAddress: senderAddress,
+							asset: otoken,
+							vaultId: 1,
+							amount: tinyAmount,
+							optionSeries: emptySeries,
+							index: 0,
+							data: "0x"
+						}]
+				},
+			])
+			const vaultId = await controller.getAccountVaultCounter(senderAddress)
+			const vaultDetails = await controller.getVaultWithDetails(senderAddress, vaultId)
+			expect(vaultId).to.equal(vaultIdCounter)
+			expect((vaultDetails)[1]).to.equal(1)
+			expect(vaultDetails[0].collateralAmounts[0]).to.equal(margin)
+			expect(vaultDetails[0].shortAmounts[0]).to.equal(tinyAmount)
+			expect(vaultDetails[0].shortOtokens[0]).to.equal(otoken)
+			const vault1Details = await controller.getVaultWithDetails(senderAddress, 1)
+			expect(vault1Details[0].longAmounts[0]).to.equal(0)
+			expect(vault1Details[0].longOtokens[0]).to.equal(ZERO_ADDRESS)
+			vaultIdCounter++
 		})
 		it("REVERTS: OPYN mint short option with collateral deposited via exchange then deposits the long option from sender in vault 1 and withdraws to exchange", async () => {
 			const margin = toUSDC("1000")
@@ -1174,37 +1180,39 @@ describe("Actions tests", async () => {
 						optionSeries: emptySeries,
 						index: 0,
 						data: "0x"
-					}]},
-					{
-						operation: 0,
-						operationQueue:[
-					{
-						actionType: 3,
-						owner: senderAddress,
-						secondAddress: senderAddress,
-						asset: otoken,
-						vaultId: 1,
-						amount: tinyAmount,
-						optionSeries: emptySeries,
-						index: 0,
-						data: "0x"
-					},
-					{
-						actionType: 4,
-						owner: senderAddress,
-						secondAddress: exchange.address,
-						asset: otoken,
-						vaultId: 1,
-						amount: tinyAmount,
-						optionSeries: emptySeries,
-						index: 0,
-						data: "0x"
-					}]},
-				])).to.be.revertedWith("TokenImbalance()")
-				await usd.approve(exchange.address, 0)
-				await otokenERC.approve(MARGIN_POOL[chainId], 0)
+					}]
+				},
+				{
+					operation: 0,
+					operationQueue: [
+						{
+							actionType: 3,
+							owner: senderAddress,
+							secondAddress: senderAddress,
+							asset: otoken,
+							vaultId: 1,
+							amount: tinyAmount,
+							optionSeries: emptySeries,
+							index: 0,
+							data: "0x"
+						},
+						{
+							actionType: 4,
+							owner: senderAddress,
+							secondAddress: exchange.address,
+							asset: otoken,
+							vaultId: 1,
+							amount: tinyAmount,
+							optionSeries: emptySeries,
+							index: 0,
+							data: "0x"
+						}]
+				},
+			])).to.be.revertedWith("TokenImbalance()")
+			await usd.approve(exchange.address, 0)
+			await otokenERC.approve(MARGIN_POOL[chainId], 0)
 		})
-	})	
+	})
 	describe("Opyn Forbidden Actions", async () => {
 		it("REVERTS: OPYN liquidate", async () => {
 			await expect(exchange.operate([

--- a/packages/contracts/test/LiquidityPoolAlpha.ts
+++ b/packages/contracts/test/LiquidityPoolAlpha.ts
@@ -42,7 +42,8 @@ import {
 	calculateOptionDeltaLocally,
 	increase,
 	setOpynOracleExpiryPrice,
-	increaseTo
+	increaseTo,
+	getNetDhvExposure
 } from "./helpers"
 import {
 	GAMMA_CONTROLLER,
@@ -64,6 +65,7 @@ import { ERC20Interface } from "../types/ERC20Interface"
 import { AlphaOptionHandler } from "../types/AlphaOptionHandler"
 import { Console } from "console"
 import { AbiCoder } from "ethers/lib/utils"
+import { OptionCatalogue } from "../types/OptionCatalogue"
 let usd: MintableERC20
 let weth: WETH
 let wethERC20: ERC20Interface
@@ -90,6 +92,7 @@ let collateralAllocatedToVault1: BigNumber
 let proposedSeries: any
 let handler: AlphaOptionHandler
 let authority: string
+let catalogue: OptionCatalogue
 
 const IMPLIED_VOL = "60"
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
@@ -244,6 +247,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 		volatility = lpParams.volatility
 		liquidityPool = lpParams.liquidityPool
 		handler = lpParams.handler
+		catalogue = lpParams.catalogue
 		signers = await hre.ethers.getSigners()
 		senderAddress = await signers[0].getAddress()
 		receiverAddress = await signers[1].getAddress()
@@ -322,15 +326,15 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)
@@ -555,7 +559,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const prevalues = await portfolioValuesFeed.getPortfolioValues(weth.address, usd.address)
 			const ephemeralDeltaBefore = await liquidityPool.ephemeralDelta()
 			const ephemeralLiabilitiesBefore = await liquidityPool.ephemeralLiabilities()
-
+			const netDhvExposureBefore = await getNetDhvExposure(orderDeets.optionSeries.strike.mul(utils.parseUnits("1", 10)), orderDeets.optionSeries.collateral, catalogue, orderDeets.optionSeries.expiration, orderDeets.optionSeries.isPut)
 			const expectedCollateralAllocated = await optionRegistry.getCollateral(
 				{
 					expiration: orderDeets.optionSeries.expiration,
@@ -622,12 +626,12 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const buyerBalAfter = await usd.balanceOf(receiverAddress)
 			const receiverBalAfter = await usd.balanceOf(receiverAddress)
 			const collateralAllocatedAfter = await liquidityPool.collateralAllocated()
+			const netDhvExposureAfter = await getNetDhvExposure(orderDeets.optionSeries.strike.mul(utils.parseUnits("1", 10)), orderDeets.optionSeries.collateral, catalogue, orderDeets.optionSeries.expiration, orderDeets.optionSeries.isPut)
 			const collateralAllocatedDiff = tFormatUSDC(
 				collateralAllocatedAfter.sub(collateralAllocatedBefore)
 			)
 			const buyerUSDBalanceDiff = buyerBalBefore.sub(buyerBalAfter)
 			const lpUSDBalanceDiff = lpUSDBalanceAfter.sub(lpUSDBalanceBefore)
-
 			const order = await handler.orderStores(customOrderId)
 			// order should be non existant
 			expect(order.buyer).to.eq(ZERO_ADDRESS)
@@ -637,7 +641,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -650,12 +654,13 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(3)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(3))
 			expect(await portfolioValuesFeed.addressSetLength()).to.equal(1)
+			expect(netDhvExposureBefore.sub(netDhvExposureAfter)).to.equal(orderDeets.amount)
 		})
 	})
 	describe("Create and execute a strangle", async () => {
@@ -934,17 +939,17 @@ describe("Liquidity Pool with alpha tests", async () => {
 			).to.be.within(-1, 1)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					(parseFloat(fromWei(orderDeets1.amount)) * tFormatEth(orderDeets1.price) +
-						parseFloat(fromWei(orderDeets2.amount)) * tFormatEth(orderDeets2.price))
+				(parseFloat(fromWei(orderDeets1.amount)) * tFormatEth(orderDeets1.price) +
+					parseFloat(fromWei(orderDeets2.amount)) * tFormatEth(orderDeets2.price))
 			).to.be.within(-0.02, 0.02)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets1.amount) * tFormatEth(orderDeets1.price) +
-						tFormatEth(orderDeets2.amount) * tFormatEth(orderDeets2.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets1.amount) * tFormatEth(orderDeets1.price) +
+					tFormatEth(orderDeets2.amount) * tFormatEth(orderDeets2.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.02, 0.02)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(3)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(3))
@@ -1035,6 +1040,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const prevalues = await portfolioValuesFeed.getPortfolioValues(weth.address, usd.address)
 			const ephemeralDeltaBefore = await liquidityPool.ephemeralDelta()
 			const ephemeralLiabilitiesBefore = await liquidityPool.ephemeralLiabilities()
+			const netDhvExposureBefore = await getNetDhvExposure(orderDeets.optionSeries.strike.mul(utils.parseUnits("1", 10)), orderDeets.optionSeries.collateral, catalogue, orderDeets.optionSeries.expiration, orderDeets.optionSeries.isPut)
 
 			const expectedCollateralAllocated = await optionRegistry.getCollateral(
 				{
@@ -1102,6 +1108,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const buyerBalAfter = await usd.balanceOf(receiverAddress)
 			const receiverBalAfter = await usd.balanceOf(receiverAddress)
 			const collateralAllocatedAfter = await liquidityPool.collateralAllocated()
+			const netDhvExposureAfter = await getNetDhvExposure(orderDeets.optionSeries.strike.mul(utils.parseUnits("1", 10)), orderDeets.optionSeries.collateral, catalogue, orderDeets.optionSeries.expiration, orderDeets.optionSeries.isPut)
 			const collateralAllocatedDiff = tFormatUSDC(
 				collateralAllocatedAfter.sub(collateralAllocatedBefore)
 			)
@@ -1119,7 +1126,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -1132,12 +1139,13 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(2)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(2))
 			expect(await portfolioValuesFeed.addressSetLength()).to.equal(4)
+			expect(netDhvExposureBefore.sub(netDhvExposureAfter)).to.equal(orderDeets.amount)
 		})
 		it("SUCCEEDS: Creates a buyback order", async () => {
 			let customOrderPriceMultiplier = 1
@@ -1300,6 +1308,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const ephemeralDeltaBefore = await liquidityPool.ephemeralDelta()
 			const ephemeralLiabilitiesBefore = await liquidityPool.ephemeralLiabilities()
 			const receiverOTokenBalBefore = await optionToken.balanceOf(receiverAddress)
+			const netDhvExposureBefore = await getNetDhvExposure(orderDeets.optionSeries.strike.mul(utils.parseUnits("1", 10)), orderDeets.optionSeries.collateral, catalogue, orderDeets.optionSeries.expiration, orderDeets.optionSeries.isPut)
 			const expectedCollateralAllocated = await optionRegistry.getCollateral(
 				{
 					expiration: orderDeets.optionSeries.expiration,
@@ -1366,6 +1375,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const buyerBalAfter = await usd.balanceOf(receiverAddress)
 			const receiverBalAfter = await usd.balanceOf(receiverAddress)
 			const collateralAllocatedAfter = await liquidityPool.collateralAllocated()
+			const netDhvExposureAfter = await getNetDhvExposure(orderDeets.optionSeries.strike.mul(utils.parseUnits("1", 10)), orderDeets.optionSeries.collateral, catalogue, orderDeets.optionSeries.expiration, orderDeets.optionSeries.isPut)
 			const collateralAllocatedDiff = tFormatUSDC(
 				collateralAllocatedBefore.sub(collateralAllocatedAfter)
 			)
@@ -1381,7 +1391,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -1394,12 +1404,13 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance decreases by agreed price plus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect((deltaAfter + tFormatEth(localDelta)).toPrecision(2)).to.eq(deltaBefore.toPrecision(2))
 			expect(await portfolioValuesFeed.addressSetLength()).to.equal(4)
+			expect(netDhvExposureAfter.sub(netDhvExposureBefore)).to.equal(orderDeets.amount)
 		})
 		it("SUCCEEDS: Creates a buyback order on the same option", async () => {
 			let customOrderPriceMultiplier = 1
@@ -1783,7 +1794,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -1796,8 +1807,8 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated)) + tFormatUSDC(await handler.feePerContract()) * tFormatEth(orderDeets.amount)
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated)) + tFormatUSDC(await handler.feePerContract()) * tFormatEth(orderDeets.amount)
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(await portfolioValuesFeed.addressSetLength()).to.equal(5)
@@ -1919,7 +1930,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -1932,8 +1943,8 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(await portfolioValuesFeed.addressSetLength()).to.equal(5)
@@ -2052,15 +2063,15 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)

--- a/packages/contracts/test/LiquidityPoolAlphaDepositWithdraw.ts
+++ b/packages/contracts/test/LiquidityPoolAlphaDepositWithdraw.ts
@@ -370,15 +370,15 @@ describe("Liquidity Pools Alpha Deposit Withdraw", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)
@@ -655,7 +655,7 @@ describe("Liquidity Pools Alpha Deposit Withdraw", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -668,8 +668,8 @@ describe("Liquidity Pools Alpha Deposit Withdraw", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(3)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(3))
@@ -1129,17 +1129,17 @@ describe("Liquidity Pools Alpha Deposit Withdraw", async () => {
 			).to.be.within(-1, 1)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					(parseFloat(fromWei(orderDeets1.amount)) * tFormatEth(orderDeets1.price) +
-						parseFloat(fromWei(orderDeets2.amount)) * tFormatEth(orderDeets2.price))
+				(parseFloat(fromWei(orderDeets1.amount)) * tFormatEth(orderDeets1.price) +
+					parseFloat(fromWei(orderDeets2.amount)) * tFormatEth(orderDeets2.price))
 			).to.be.within(-0.02, 0.02)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets1.amount) * tFormatEth(orderDeets1.price) +
-						tFormatEth(orderDeets2.amount) * tFormatEth(orderDeets2.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets1.amount) * tFormatEth(orderDeets1.price) +
+					tFormatEth(orderDeets2.amount) * tFormatEth(orderDeets2.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.02, 0.02)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(3)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(3))
@@ -1172,15 +1172,15 @@ describe("Liquidity Pools Alpha Deposit Withdraw", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)
@@ -1425,15 +1425,15 @@ describe("Liquidity Pools Alpha Deposit Withdraw", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)

--- a/packages/contracts/test/LiquidityPoolAlphaWithManager.ts
+++ b/packages/contracts/test/LiquidityPoolAlphaWithManager.ts
@@ -392,15 +392,15 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)
@@ -436,9 +436,9 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const reactorDelta = await perpHedgingReactor.internalDelta()
 			await expect(manager.connect(receiver).rebalancePortfolioDelta(delta, 0, { gasLimit: 999999999999 })).to.be.revertedWith("NotKeeper()")
 		})
-		it("SUCCEEDS: sets keeper", async() => {
+		it("SUCCEEDS: sets keeper", async () => {
 			await manager.setKeeper(receiverAddress, true)
-			expect( await manager.keeper(receiverAddress)).to.be.true
+			expect(await manager.keeper(receiverAddress)).to.be.true
 		})
 		it("REVERTS: hedges delta in perp hedging reactor via keeper with no delta limit", async () => {
 			const [sender, receiver] = signers
@@ -446,16 +446,16 @@ describe("Liquidity Pool with alpha tests", async () => {
 			const reactorDelta = await perpHedgingReactor.internalDelta()
 			await expect(manager.connect(receiver).rebalancePortfolioDelta(delta, 0, { gasLimit: 999999999999 })).to.be.revertedWith("ExceedsDeltaLimit()")
 		})
-		it("SUCCEEDS: proxy manager sets delta limit", async() => {
+		it("SUCCEEDS: proxy manager sets delta limit", async () => {
 			await manager.setDeltaLimit([toWei("1")], [receiverAddress])
-			expect( await manager.deltaLimit(receiverAddress)).to.equal(toWei("1"))
+			expect(await manager.deltaLimit(receiverAddress)).to.equal(toWei("1"))
 		})
-		it("SUCCEEDS: proxy manager sets multiple delta limit", async() => {
+		it("SUCCEEDS: proxy manager sets multiple delta limit", async () => {
 			await manager.setDeltaLimit([toWei("1"), toWei("2")], [receiverAddress, senderAddress])
-			expect( await manager.deltaLimit(receiverAddress)).to.equal(toWei("1"))
-			expect( await manager.deltaLimit(senderAddress)).to.equal(toWei("2"))
+			expect(await manager.deltaLimit(receiverAddress)).to.equal(toWei("1"))
+			expect(await manager.deltaLimit(senderAddress)).to.equal(toWei("2"))
 		})
-		it("REVERTS: non proxy manager sets delta limit", async() => {
+		it("REVERTS: non proxy manager sets delta limit", async () => {
 			const [sender, receiver] = signers
 			await expect(manager.connect(receiver).setDeltaLimit([toWei("1")], [receiverAddress])).to.be.revertedWith("NotProxyManager()")
 		})
@@ -538,7 +538,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 				amount
 			)
 			customOrderPrice = localQuote * customOrderPriceMultiplier
-			customOrderId = await handler.callStatic.createOrder(				
+			customOrderId = await handler.callStatic.createOrder(
 				proposedSeries,
 				amount,
 				toWei(customOrderPrice.toString()).mul(toWei("1")).div(amount),
@@ -792,7 +792,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -805,8 +805,8 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(3)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(3))
@@ -1094,17 +1094,17 @@ describe("Liquidity Pool with alpha tests", async () => {
 			).to.be.within(-1, 1)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					(parseFloat(fromWei(orderDeets1.amount)) * tFormatEth(orderDeets1.price) +
-						parseFloat(fromWei(orderDeets2.amount)) * tFormatEth(orderDeets2.price))
+				(parseFloat(fromWei(orderDeets1.amount)) * tFormatEth(orderDeets1.price) +
+					parseFloat(fromWei(orderDeets2.amount)) * tFormatEth(orderDeets2.price))
 			).to.be.within(-0.02, 0.02)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets1.amount) * tFormatEth(orderDeets1.price) +
-						tFormatEth(orderDeets2.amount) * tFormatEth(orderDeets2.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets1.amount) * tFormatEth(orderDeets1.price) +
+					tFormatEth(orderDeets2.amount) * tFormatEth(orderDeets2.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.02, 0.02)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(3)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(3))
@@ -1142,7 +1142,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 				amount
 			)
 			customOrderPrice = localQuote * customOrderPriceMultiplier
-			customOrderId = await handler.callStatic.createOrder(				
+			customOrderId = await handler.callStatic.createOrder(
 				proposedSeries,
 				amount,
 				toWei(customOrderPrice.toString()).mul(toWei("1")).div(amount),
@@ -1284,7 +1284,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -1297,8 +1297,8 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance increases by agreed price minus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect(deltaAfter.toPrecision(2)).to.eq((deltaBefore + tFormatEth(localDelta)).toPrecision(2))
@@ -1330,7 +1330,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 				amount
 			)
 			customOrderPrice = localQuote * customOrderPriceMultiplier
-			customOrderId = await handler.callStatic.createOrder(				
+			customOrderId = await handler.callStatic.createOrder(
 				proposedSeries,
 				amount,
 				toWei(customOrderPrice.toString()).mul(toWei("1")).div(amount),
@@ -1582,7 +1582,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 			expect(lpOTokenBalAfter).to.eq(0)
 			expect(
 				tFormatUSDC(buyerUSDBalanceDiff) -
-					parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
+				parseFloat(fromWei(orderDeets.amount)) * tFormatEth(orderDeets.price)
 			).to.be.within(-0.01, 0.01)
 			// check collateralAllocated is correct
 			expect(collateralAllocatedDiff).to.eq(tFormatUSDC(expectedCollateralAllocated))
@@ -1595,8 +1595,8 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check liquidity pool USD balance decreases by agreed price plus collateral
 			expect(
 				tFormatUSDC(lpUSDBalanceDiff) -
-					(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
-						tFormatUSDC(expectedCollateralAllocated))
+				(tFormatEth(orderDeets.amount) * tFormatEth(orderDeets.price) -
+					tFormatUSDC(expectedCollateralAllocated))
 			).to.be.within(-0.015, 0.015)
 			// check delta changes by expected amount
 			expect((deltaAfter + tFormatEth(localDelta)).toPrecision(2)).to.eq(deltaBefore.toPrecision(2))
@@ -1628,7 +1628,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 				amount
 			)
 			customOrderPrice = localQuote * customOrderPriceMultiplier
-			customOrderId = await handler.callStatic.createOrder(				
+			customOrderId = await handler.callStatic.createOrder(
 				proposedSeries,
 				amount,
 				toWei(customOrderPrice.toString()).mul(toWei("1")).div(amount),
@@ -1745,7 +1745,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 				amount
 			)
 			customOrderPrice = localQuote * customOrderPriceMultiplier
-			customOrderId = await handler.callStatic.createOrder(				
+			customOrderId = await handler.callStatic.createOrder(
 				proposedSeries,
 				amount,
 				toWei(customOrderPrice.toString()).mul(toWei("1")).div(amount),
@@ -1817,7 +1817,7 @@ describe("Liquidity Pool with alpha tests", async () => {
 				underlying: weth.address,
 				collateral: usd.address
 			}
-			customOrderId = await handler.callStatic.createOrder(				
+			customOrderId = await handler.callStatic.createOrder(
 				proposedSeries,
 				amount,
 				toWei(customOrderPrice.toString()).mul(toWei("1")).div(amount),
@@ -1993,15 +1993,15 @@ describe("Liquidity Pool with alpha tests", async () => {
 			// check partitioned funds increased by pendingWithdrawals * price per share
 			expect(
 				parseFloat(fromWei(partitionedFundsDiffe18)) -
-					parseFloat(fromWei(pendingWithdrawBefore)) *
-						parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
+				parseFloat(fromWei(pendingWithdrawBefore)) *
+				parseFloat(fromWei(await liquidityPool.withdrawalEpochPricePerShare(withdrawalEpochBefore)))
 			).to.be.within(-0.0001, 0.0001)
 			expect(await liquidityPool.depositEpochPricePerShare(depositEpochBefore)).to.equal(
 				totalSupplyBefore.eq(0)
 					? toWei("1")
 					: toWei("1")
-							.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
-							.div(totalSupplyBefore)
+						.mul((await liquidityPool.getNAV()).add(partitionedFundsDiffe18).sub(pendingDepositBefore))
+						.div(totalSupplyBefore)
 			)
 			expect(await liquidityPool.pendingDeposits()).to.equal(0)
 			expect(pendingDepositBefore).to.not.eq(0)

--- a/packages/contracts/test/LiquidityPoolDepositWithdraw.ts
+++ b/packages/contracts/test/LiquidityPoolDepositWithdraw.ts
@@ -56,6 +56,7 @@ import { Accounting } from "../types/Accounting"
 import exp from "constants"
 import { BeyondPricer } from "../types/BeyondPricer"
 import { OptionExchange } from "../types/OptionExchange"
+import { OptionCatalogue } from "../types/OptionCatalogue"
 
 let usd: MintableERC20
 let weth: WETH
@@ -82,6 +83,7 @@ let quote: any
 let localDelta: any
 let authority: string
 let accounting: Accounting
+let catalogue: OptionCatalogue
 
 /* --- variables to change --- */
 
@@ -188,6 +190,7 @@ describe("Liquidity Pools Deposit Withdraw", async () => {
 		exchange = lpParams.exchange
 		pricer = lpParams.pricer
 		accounting = lpParams.accounting
+		catalogue = lpParams.catalogue
 		signers = await hre.ethers.getSigners()
 		senderAddress = await signers[0].getAddress()
 		receiverAddress = await signers[1].getAddress()
@@ -607,7 +610,7 @@ describe("Liquidity Pools Deposit Withdraw", async () => {
 	it("SETUP: approve series", async () => {
 		const priceQuote = await priceFeed.getNormalizedRate(weth.address, usd.address)
 		const strikePrice = priceQuote.sub(toWei(strike))
-		await exchange.issueNewSeries([
+		await catalogue.issueNewSeries([
 			{
 				expiration: expiration,
 				isPut: PUT_FLAVOR,
@@ -933,7 +936,7 @@ describe("Liquidity Pools Deposit Withdraw", async () => {
 	it("SETUP: approve series", async () => {
 		const priceQuote = await priceFeed.getNormalizedRate(weth.address, usd.address)
 		const strikePrice = priceQuote.sub(toWei(strike))
-		await exchange.issueNewSeries([
+		await catalogue.issueNewSeries([
 			{
 				expiration: expiration,
 				isPut: CALL_FLAVOR,

--- a/packages/contracts/test/LiquidityPoolPerpHedgingReactor.ts
+++ b/packages/contracts/test/LiquidityPoolPerpHedgingReactor.ts
@@ -68,6 +68,7 @@ import { AlphaPortfolioValuesFeed } from "../types/AlphaPortfolioValuesFeed"
 import { deployLiquidityPool, deploySystem } from "../utils/generic-system-deployer"
 import { BeyondPricer } from "../types/BeyondPricer"
 import { OptionExchange } from "../types/OptionExchange"
+import { OptionCatalogue } from "../types/OptionCatalogue"
 
 let usd: MintableERC20
 let weth: WETH
@@ -101,6 +102,7 @@ let collateralId: string
 let exchange: OptionExchange
 let pricer: BeyondPricer
 let authority: string
+let catalogue: OptionCatalogue
 
 const IMPLIED_VOL = "60"
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
@@ -236,6 +238,7 @@ describe("Liquidity Pools hedging reactor: perps", async () => {
 		liquidityPool = lpParams.liquidityPool
 		exchange = lpParams.exchange
 		pricer = lpParams.pricer
+		catalogue = lpParams.catalogue
 		signers = await hre.ethers.getSigners()
 		senderAddress = await signers[0].getAddress()
 		receiverAddress = await signers[1].getAddress()
@@ -355,7 +358,7 @@ describe("Liquidity Pools hedging reactor: perps", async () => {
 	it("SETUP: approve series", async () => {
 		const priceQuote = await priceFeed.getNormalizedRate(weth.address, usd.address)
 		const strikePrice = priceQuote.sub(toWei(strike))
-		await exchange.issueNewSeries([
+		await catalogue.issueNewSeries([
 			{
 				expiration: expiration,
 				isPut: PUT_FLAVOR,

--- a/packages/contracts/test/LiquidityPoolSellOptions.ts
+++ b/packages/contracts/test/LiquidityPoolSellOptions.ts
@@ -556,7 +556,7 @@ describe("Liquidity Pools hedging reactor: gamma", async () => {
 						data: "0x"
 					}]
 				}])).to.be.revertedWith("MaxNetDhvExposureExceeded()")
-	
+
 		})
 		it("REVERTS: sells the options to the exchange and go below net dhv exposure", async () => {
 			const amount = toWei("1")

--- a/packages/contracts/test/LiquidityPoolUniswapV3HedgingReactor.ts
+++ b/packages/contracts/test/LiquidityPoolUniswapV3HedgingReactor.ts
@@ -66,6 +66,7 @@ import { AlphaPortfolioValuesFeed } from "../types/AlphaPortfolioValuesFeed"
 import { deployLiquidityPool, deploySystem } from "../utils/generic-system-deployer"
 import { BeyondPricer } from "../types/BeyondPricer"
 import { OptionExchange } from "../types/OptionExchange"
+import { OptionCatalogue } from "../types/OptionCatalogue"
 let usd: MintableERC20
 let weth: WETH
 let optionRegistry: OptionRegistry
@@ -91,7 +92,7 @@ let uniswapV3HedgingReactor: UniswapV3HedgingReactor
 let exchange: OptionExchange
 let pricer: BeyondPricer
 let authority: string
-
+let catalogue: OptionCatalogue
 const IMPLIED_VOL = "60"
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
@@ -226,6 +227,7 @@ describe("Liquidity Pools hedging reactor: univ3", async () => {
 		liquidityPool = lpParams.liquidityPool
 		exchange = lpParams.exchange
 		pricer = lpParams.pricer
+		catalogue = lpParams.catalogue
 		signers = await hre.ethers.getSigners()
 		senderAddress = await signers[0].getAddress()
 		receiverAddress = await signers[1].getAddress()
@@ -335,7 +337,7 @@ describe("Liquidity Pools hedging reactor: univ3", async () => {
 	it("SETUP: approve series", async () => {
 		const priceQuote = await priceFeed.getNormalizedRate(weth.address, usd.address)
 		const strikePrice = priceQuote.add(toWei(strike))
-		await exchange.issueNewSeries([
+		await catalogue.issueNewSeries([
 			{
 				expiration: expiration,
 				isPut: CALL_FLAVOR,

--- a/packages/contracts/test/foundry/Slippage.t.sol
+++ b/packages/contracts/test/foundry/Slippage.t.sol
@@ -19,11 +19,11 @@ contract SlippageTest is Test {
 	uint256 deltaBandWidth;
 
 	function setUp() public {
-        minAmount = 1e16;
+        minAmount = 1e15;
 		callSlippageGradientMultipliers = [1e18, 1.1e18, 1.2e18, 1.3e18, 1.4e18, 1.5e18, 1.6e18, 1.7e18, 1.8e18, 1.9e18, 2.0e18, 2.1e18, 2.2e18, 2.3e18, 2.4e18, 2.5e18, 2.6e18, 2.7e18, 2.8e18, 2.9e18];
 		putSlippageGradientMultipliers = [1e18, 1.1e18, 1.2e18, 1.3e18, 1.4e18, 1.5e18, 1.6e18, 1.7e18, 1.8e18, 1.9e18, 2.0e18, 2.1e18, 2.2e18, 2.3e18, 2.4e18, 2.5e18, 2.6e18, 2.7e18, 2.8e18, 2.9e18];
 		deltaBandWidth = 5e18;
-		slippageGradient = 1e15;
+		slippageGradient = 1e16;
 	}
 
 
@@ -52,7 +52,6 @@ contract SlippageTest is Test {
 		_getSlippageMultiplier(1e16, _delta, -100e18, true);
 		_getSlippageMultiplier(1e16, _delta, -100e18, false);
 	}
-
 	function testSlippageMultiplierFuzzNetDhvExposure(int96 _netDhvExposure) public {
 		vm.assume(_netDhvExposure <= 50000e18);
 		vm.assume(_netDhvExposure >= -50000e18);
@@ -64,6 +63,21 @@ contract SlippageTest is Test {
 		_getSlippageMultiplier(1e16, -5e17, _netDhvExposure, false);
 		_getSlippageMultiplier(1e16, 5e17, _netDhvExposure, true);
 		_getSlippageMultiplier(1e16, -5e17, _netDhvExposure, false);
+	}
+
+
+	function testSlippageMultiplierFuzzSlippageGradient(uint64 _slippageGradient) public {
+		vm.assume(_slippageGradient >= 1e12);
+		vm.assume(_slippageGradient <= 0.1e18);
+		slippageGradient = _slippageGradient;
+        _getSlippageMultiplier(1000e18, 5e17, 100e18, true);
+		_getSlippageMultiplier(1000e18, -5e17, 100e18, false);
+		_getSlippageMultiplier(1000e18, 5e17, -100e18, true);
+		_getSlippageMultiplier(1000e18, -5e17, -100e18, false);
+		_getSlippageMultiplier(1e16, 5e17, 100e18, true);
+		_getSlippageMultiplier(1e16, -5e17, 100e18, false);
+		_getSlippageMultiplier(1e16, 5e17, -100e18, true);
+		_getSlippageMultiplier(1e16, -5e17, -100e18, false);
 	}
 
 	// function testSlippageFFIGetSlippageMultiplier() public {

--- a/packages/contracts/test/helpers.ts
+++ b/packages/contracts/test/helpers.ts
@@ -98,7 +98,7 @@ export async function compareQuotes(
 	pricer,
 	netDhvExposureOverride: BigNumberish = 1
 ) {
-	const catalogue = await ethers.getContractAt("OptionCatalogue",(await exchange.catalogue())) as OptionCatalogue
+	const catalogue = await ethers.getContractAt("OptionCatalogue", (await exchange.catalogue())) as OptionCatalogue
 	const feePerContract = await pricer.feePerContract()
 	const localDelta = await calculateOptionDeltaLocally(
 		liquidityPool,
@@ -176,7 +176,7 @@ export async function getExchangeParams(
 		netDhvExposure = await getNetDhvExposure(
 			(await optionToken.strikePrice()).mul(utils.parseUnits("1", 10)),
 			usd.address,
-			await ethers.getContractAt("OptionCatalogue",(await exchange.catalogue())) as OptionCatalogue,
+			await ethers.getContractAt("OptionCatalogue", (await exchange.catalogue())) as OptionCatalogue,
 			await optionToken.expiryTimestamp(),
 			await optionToken.isPut()
 		)
@@ -716,7 +716,7 @@ export async function applySlippageLocally(
 	let modifiedSlippageGradient
 	const deltaBandIndex = Math.floor(
 		(parseFloat(fromWei(optionDelta.abs())) * 100) /
-			parseFloat(fromWei(await beyondPricer.deltaBandWidth()))
+		parseFloat(fromWei(await beyondPricer.deltaBandWidth()))
 	)
 	console.log({
 		deltaBandIndex,
@@ -746,11 +746,11 @@ export async function applySlippageLocally(
 	console.log(fromWei(amount))
 	const slippagePremium = isSell
 		? (slippageFactor ** -oldExposureCoefficient - slippageFactor ** -newExposureCoefficient) /
-		  Math.log(slippageFactor) /
-		  parseFloat(fromWei(amount))
+		Math.log(slippageFactor) /
+		parseFloat(fromWei(amount))
 		: (slippageFactor ** -newExposureCoefficient - slippageFactor ** -oldExposureCoefficient) /
-		  Math.log(slippageFactor) /
-		  parseFloat(fromWei(amount))
+		Math.log(slippageFactor) /
+		parseFloat(fromWei(amount))
 	console.log({ modifiedSlippageGradient, slippagePremium })
 	return slippagePremium
 }

--- a/packages/contracts/test/helpers.ts
+++ b/packages/contracts/test/helpers.ts
@@ -44,6 +44,7 @@ import { BeyondPricer } from "../types/BeyondPricer"
 import { OptionExchange } from "../types/OptionExchange"
 import { priceToPriceX128 } from "@ragetrade/sdk"
 import { ln } from "prb-math"
+import { OptionCatalogue } from "../types/OptionCatalogue"
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 const ONE_YEAR_SECONDS = 31557600
@@ -58,15 +59,15 @@ const aboveUtilizationThresholdGradient = 1
 const utilizationFunctionThreshold = 0.6 // 60%
 const yIntercept = -0.6
 
-export async function getNetDhvExposure(strikePrice, collateral, exchange, expiration, flavor) {
-	const formattedStrikePrice = (await exchange.formatStrikePrice(strikePrice, collateral)).mul(
+export async function getNetDhvExposure(strikePrice, collateral, catalogue, expiration, flavor) {
+	const formattedStrikePrice = (await catalogue.formatStrikePrice(strikePrice, collateral)).mul(
 		ethers.utils.parseUnits("1", 10)
 	)
 	const oHash = ethers.utils.solidityKeccak256(
 		["uint64", "uint128", "bool"],
 		[expiration, formattedStrikePrice, flavor]
 	)
-	return await exchange.netDhvExposure(oHash)
+	return await catalogue.netDhvExposure(oHash)
 }
 export async function getSeriesWithe18Strike(proposedSeries, optionRegistry) {
 	const formattedStrike = await optionRegistry.formatStrikePrice(
@@ -97,6 +98,7 @@ export async function compareQuotes(
 	pricer,
 	netDhvExposureOverride: BigNumberish = 1
 ) {
+	const catalogue = await ethers.getContractAt("OptionCatalogue",(await exchange.catalogue())) as OptionCatalogue
 	const feePerContract = await pricer.feePerContract()
 	const localDelta = await calculateOptionDeltaLocally(
 		liquidityPool,
@@ -114,7 +116,7 @@ export async function compareQuotes(
 		amount,
 		pricer,
 		isSell,
-		exchange,
+		catalogue,
 		localDelta.div(amount.div(toWei("1"))),
 		netDhvExposureOverride
 	)
@@ -174,7 +176,7 @@ export async function getExchangeParams(
 		netDhvExposure = await getNetDhvExposure(
 			(await optionToken.strikePrice()).mul(utils.parseUnits("1", 10)),
 			usd.address,
-			exchange,
+			await ethers.getContractAt("OptionCatalogue",(await exchange.catalogue())) as OptionCatalogue,
 			await optionToken.expiryTimestamp(),
 			await optionToken.isPut()
 		)
@@ -644,7 +646,7 @@ export async function localQuoteOptionPrice(
 	amount: BigNumber,
 	pricer,
 	isSell: boolean, // from perspective of user,
-	exchange: OptionExchange,
+	catalogue: OptionCatalogue,
 	optionDelta: BigNumber,
 	netDhvExposure: BigNumberish = 1
 ) {
@@ -660,7 +662,7 @@ export async function localQuoteOptionPrice(
 	)
 	const slip = await applySlippageLocally(
 		pricer,
-		exchange,
+		catalogue,
 		optionSeries,
 		amount,
 		optionDelta,
@@ -686,7 +688,7 @@ export async function localQuoteOptionPrice(
 
 export async function applySlippageLocally(
 	beyondPricer: BeyondPricer,
-	exchange: OptionExchange,
+	catalogue: OptionCatalogue,
 	optionSeries: OptionSeriesStruct,
 	amount: BigNumber,
 	optionDelta: BigNumber,
@@ -694,14 +696,14 @@ export async function applySlippageLocally(
 	netDhvExposure: BigNumberish = 1
 ) {
 	const formattedStrikePrice = (
-		await exchange.formatStrikePrice(optionSeries.strike, optionSeries.collateral)
+		await catalogue.formatStrikePrice(optionSeries.strike, optionSeries.collateral)
 	).mul(ethers.utils.parseUnits("1", 10))
 	const oHash = ethers.utils.solidityKeccak256(
 		["uint64", "uint128", "bool"],
 		[optionSeries.expiration, formattedStrikePrice, optionSeries.isPut]
 	)
 	if (netDhvExposure == 1) {
-		netDhvExposure = await exchange.netDhvExposure(oHash)
+		netDhvExposure = await catalogue.netDhvExposure(oHash)
 	}
 
 	console.log({ oHash }, netDhvExposure.toString())

--- a/packages/contracts/utils/alpha-system-deployer.ts
+++ b/packages/contracts/utils/alpha-system-deployer.ts
@@ -243,7 +243,8 @@ export async function deployLiquidityPool(
 	const catalogueFactory = await ethers.getContractFactory("OptionCatalogue")
 	const catalogue = (await catalogueFactory.deploy(
 		authority,
-		usd.address
+		usd.address,
+		toWei("50000")
 	)) as OptionCatalogue
 	const handlerFactory = await ethers.getContractFactory("AlphaOptionHandler")
 	const handler = (await handlerFactory.deploy(

--- a/packages/contracts/utils/generic-system-deployer.ts
+++ b/packages/contracts/utils/generic-system-deployer.ts
@@ -308,7 +308,8 @@ export async function deployLiquidityPool(
 	const catalogueFactory = await ethers.getContractFactory("OptionCatalogue")
 	const catalogue = (await catalogueFactory.deploy(
 		authority,
-		usd.address
+		usd.address,
+		toWei("50000")
 	)) as OptionCatalogue
 	const exchangeFactory = await ethers.getContractFactory("OptionExchange", {
 		libraries: {


### PR DESCRIPTION
# Task:

## Description

- Add OptionCatalogue for options cataloguing and netdhv exposure tracking
- Add max check on netdhvexposure
- Add netdhvexposure update on AlphaOptionHandler
- Add min and max amount checks on exchange trades
- Fix test suite for all of above

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [x] Quality of life improvement

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have NATSPEC'd any new functions
- [x] If appropriate, I have properly tested my new functionality
