### PR TITLE
Liquidation calcs

### DIFF
--- a/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/components/Pricing.tsx
+++ b/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/components/Pricing.tsx
@@ -18,6 +18,7 @@ export const Pricing = ({ loading, positionData, type }: PricingProps) => {
   const {
     collateral,
     fee,
+    liquidationPrice,
     now,
     premium,
     quote,
@@ -73,6 +74,14 @@ export const Pricing = ({ loading, positionData, type }: PricingProps) => {
             {collateralType === "USDC" ? ` USDC` : ` WETH`}
           </motion.p>
         </AnimatePresence>
+      </span>
+
+      <span className="flex" id="sell-total-price">
+        <p className="mr-auto">{`Liquidation Price:`}</p>
+        <p className="font-medium">
+          <RyskCountUp value={liquidationPrice} />
+          {` USDC`}
+        </p>
       </span>
 
       <span

--- a/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/hooks/useSellOption.tsx
+++ b/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/hooks/useSellOption.tsx
@@ -132,7 +132,15 @@ export const useSellOption = (amountToSell: string) => {
                 : fromRyskToNumber(multipliedCollateral.toString());
               const maximum = USDCCollateral ? strike * amount : amount;
 
-              return Math.min(formatted, maximum);
+              if (selectedOption.callOrPut === "put") {
+                return USDCCollateral
+                  ? Math.min(formatted, maximum)
+                  : formatted;
+              } else {
+                return USDCCollateral
+                  ? formatted
+                  : Math.min(formatted, maximum);
+              }
             }
           };
 

--- a/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/hooks/useSellOption.tsx
+++ b/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/hooks/useSellOption.tsx
@@ -58,7 +58,7 @@ export const useSellOption = (amountToSell: string) => {
 
   // User position state.
   const [purchaseData, setPurchaseData] = useState<PositionDataState>({
-    acceptablePremium:BigNumber.from(0),
+    acceptablePremium: BigNumber.from(0),
     callOrPut: selectedOption?.callOrPut,
     collateral: 0,
     expiry: dayjs.unix(Number(activeExpiry)).format("DDMMMYY"),
@@ -87,14 +87,15 @@ export const useSellOption = (amountToSell: string) => {
         if (amount > 0 && ethPrice && selectedOption) {
           const strike = selectedOption.strikeOptions.strike;
 
-          const {acceptablePremium, fee, premium, quote, slippage } = await getQuote(
-            Number(activeExpiry),
-            toRysk(strike.toString()),
-            selectedOption.callOrPut === "put",
-            amount,
-            selectedOption.buyOrSell === "sell",
-            collateralPreferences.type
-          );
+          const { acceptablePremium, fee, premium, quote, slippage } =
+            await getQuote(
+              Number(activeExpiry),
+              toRysk(strike.toString()),
+              selectedOption.callOrPut === "put",
+              amount,
+              selectedOption.buyOrSell === "sell",
+              collateralPreferences.type
+            );
 
           const _getCollateralAmount = async () => {
             const requiredCollateral = await readContract({
@@ -163,7 +164,7 @@ export const useSellOption = (amountToSell: string) => {
           setAllowance((currentState) => ({ ...currentState, approved }));
         } else {
           setPurchaseData({
-            acceptablePremium:BigNumber.from(0),
+            acceptablePremium: BigNumber.from(0),
             callOrPut: selectedOption?.callOrPut,
             collateral: 0,
             expiry: dayjs.unix(Number(activeExpiry)).format("DDMMMYY"),

--- a/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/types.ts
+++ b/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/types.ts
@@ -8,6 +8,7 @@ export interface PositionDataState {
   collateral: number;
   expiry: string;
   fee: number;
+  liquidationPrice: number;
   now: string;
   premium: number;
   quote: number;

--- a/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/README.md
+++ b/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/README.md
@@ -1,0 +1,56 @@
+# Getting liquidation prices from Collateral values
+
+## Calls
+
+The original collateral calculation is as follows:
+
+`Collat(s,p,t) = P(t) ⋆ min(p, spot_shock ⋆ s) + max(p − spot_shock ⋆ s, 0)`
+
+This can be reversed to find the liquidation price as follows:
+
+```sh
+if:
+    Collat(s,p,t)
+  ----------------- > P(t)
+    spot_shock * s
+
+  p = Collat(s,p,t) − (P(t) − 1) ⋆ (spot_shock ⋆ s)
+
+else if:
+    Collat(s,p,t)
+  ----------------- < P(t)
+    spot_shock * s
+
+        Collat(s,p,t)
+  p = -----------------
+            P(t)
+
+else:
+  p = spot_shock * s
+```
+
+## Puts
+
+The original collateral calculation is as follows:
+
+`Collat(s,p,t) = P(t) ⋆ min(s, spot_shock ⋆ p) + max(s − spot_shock ⋆ p, 0)`
+
+This can be reversed to find the liquidation price as follows:
+
+```sh
+if:
+  s ⋆ P(t) < Collat(s,p,t)
+
+         Collat(s,p,t) − s
+  p = -----------------------
+      (P(t) − 1) ⋆ spot_shock
+
+else if:
+  s ⋆ P(t) >= Collat(s,p,t)
+
+            s
+  p = --------------
+        spot_shock
+```
+
+Document created by David Shaw, April 18, 2023.

--- a/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/index.ts
+++ b/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/index.ts
@@ -76,23 +76,20 @@ export const getLiquidationPrice = async (
   const shock = spotShock[callOrPut][collateralType];
 
   switch (true) {
-    case !isPut && adjustedCollateral / (shock * strikePrice) > maxPrice:
+    case !isPut && adjustedCollateral > maxPrice * shock * strikePrice:
       return truncate(
-        (adjustedCollateral - (maxPrice - 1) * (shock * strikePrice)) 
+        adjustedCollateral + (1 - maxPrice) * shock * strikePrice 
       );
 
-    case !isPut && adjustedCollateral / (shock * strikePrice) < maxPrice:
+    case !isPut && adjustedCollateral <= maxPrice * shock * strikePrice:
       return truncate(adjustedCollateral / maxPrice);
 
-    case !isPut && adjustedCollateral / (shock * strikePrice) === maxPrice:
-      return truncate((shock * strikePrice));
-
-    case isPut && strikePrice * maxPrice < adjustedCollateral:
+    case isPut && adjustedCollateral > strikePrice * maxPrice:
       return truncate(
-        (adjustedCollateral - strikePrice / ((maxPrice - 1) * shock))
+        (strikePrice - adjustedCollateral) / ((1 - maxPrice) * shock)
       );
 
-    case isPut && strikePrice * maxPrice >= adjustedCollateral:
+    case isPut && adjustedCollateral <= strikePrice * maxPrice:
       return strikePrice / shock;
 
     default:

--- a/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/index.ts
+++ b/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/index.ts
@@ -1,0 +1,100 @@
+import type { CallOrPut, SpotShock, TimesToExpiry } from "src/state/types";
+
+import dayjs from "dayjs";
+import { BigNumber } from "ethers";
+
+import { readContract } from "@wagmi/core";
+
+import { getContractAddress } from "src/utils/helpers";
+import { NewMarginCalculatorABI } from "src/abis/NewMarginCalculator_ABI";
+import { fromE27toInt, truncate } from "src/utils/conversion-helper";
+
+const USDC = getContractAddress("USDC");
+const WETH = getContractAddress("WETH");
+
+/**
+ * Utility function for calculating the liquidation price of a short position.
+ *
+ * For greater detail, please see the adjoining document. Notated values in
+ * said document match up with the following parameters within this function.
+ *
+ * |------------------|------------------|
+ * |  Function Param  |  Document Param  |
+ * |------------------|------------------|
+ * |  collateral      |  Collat(s,p,t)   |
+ * |  spotShock       |  spot_shock      |
+ * |  strikePrice     |  s               |
+ * |  maxPrice        |  P(t)            |
+ * |  return value    |  p               |
+ * |------------------|------------------|
+ *
+ * @param amount - The order size the user wishes to sell.
+ * @param callOrPut - The flavor of the option.
+ * @param collateral - The amount of collateral the user is providing.
+ * @param collateralAddress - The address of the collateral type being used.
+ * @param ethPrice - The current oracle Ether price.
+ * @param expiry - The expiry of the option in unix time.
+ * @param spotShock - A dict of values for all collateral types & flavors.
+ * @param strikePrice - The strike price of the option.
+ * @param timesToExpiry - A dict of values for all collateral types & flavors.
+ *
+ * @returns - The liquidation price for the position.
+ */
+export const getLiquidationPrice = async (
+  amount: number,
+  callOrPut: CallOrPut,
+  collateral: number,
+  collateralAddress: HexString,
+  ethPrice: number,
+  expiry: number,
+  spotShock: SpotShock,
+  strikePrice: number,
+  timesToExpiry: TimesToExpiry
+) => {
+  const collateralType = collateralAddress === USDC ? "USDC" : "WETH";
+  const now = dayjs().unix();
+
+  // Get contract call args.
+  const timeToExpiry = timesToExpiry[callOrPut][collateralType].find(
+    (time) => time >= expiry - now
+  );
+  const isPut = callOrPut === "put";
+
+  // get maxPrice.
+  const getMaxPriceResponse = await readContract({
+    abi: NewMarginCalculatorABI,
+    address: getContractAddress("OpynNewCalculator"),
+    functionName: "getMaxPrice",
+    args: [WETH, USDC, collateralAddress, isPut, BigNumber.from(timeToExpiry)],
+  });
+  const maxPrice = fromE27toInt(getMaxPriceResponse);
+
+  // Adjust params based on collateral type.
+  const adjustedCollateral =
+    collateralType === "USDC" ? collateral : ethPrice * collateral;
+  const shock = spotShock[callOrPut][collateralType];
+
+  switch (true) {
+    case !isPut && adjustedCollateral / (shock * strikePrice) > maxPrice:
+      return truncate(
+        (adjustedCollateral - (maxPrice - 1) * (shock * strikePrice)) / amount
+      );
+
+    case !isPut && adjustedCollateral / (shock * strikePrice) < maxPrice:
+      return truncate(adjustedCollateral / maxPrice / amount);
+
+    case !isPut && adjustedCollateral / (shock * strikePrice) === maxPrice:
+      return truncate((shock * strikePrice) / amount);
+
+    case isPut && strikePrice * maxPrice < adjustedCollateral:
+      return truncate(
+        (adjustedCollateral - strikePrice / ((maxPrice - 1) * shock)) / amount
+      );
+
+    case isPut && strikePrice * maxPrice >= adjustedCollateral:
+      return strikePrice / shock;
+
+    default:
+      return 0;
+  }
+};

--- a/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/index.ts
+++ b/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice/index.ts
@@ -70,25 +70,26 @@ export const getLiquidationPrice = async (
   const maxPrice = fromE27toInt(getMaxPriceResponse);
 
   // Adjust params based on collateral type.
-  const adjustedCollateral =
+  const formattedCollateral =
     collateralType === "USDC" ? collateral : ethPrice * collateral;
+  const adjustedCollateral = formattedCollateral / amount;
   const shock = spotShock[callOrPut][collateralType];
 
   switch (true) {
     case !isPut && adjustedCollateral / (shock * strikePrice) > maxPrice:
       return truncate(
-        (adjustedCollateral - (maxPrice - 1) * (shock * strikePrice)) / amount
+        (adjustedCollateral - (maxPrice - 1) * (shock * strikePrice)) 
       );
 
     case !isPut && adjustedCollateral / (shock * strikePrice) < maxPrice:
-      return truncate(adjustedCollateral / maxPrice / amount);
+      return truncate(adjustedCollateral / maxPrice);
 
     case !isPut && adjustedCollateral / (shock * strikePrice) === maxPrice:
-      return truncate((shock * strikePrice) / amount);
+      return truncate((shock * strikePrice));
 
     case isPut && strikePrice * maxPrice < adjustedCollateral:
       return truncate(
-        (adjustedCollateral - strikePrice / ((maxPrice - 1) * shock)) / amount
+        (adjustedCollateral - strikePrice / ((maxPrice - 1) * shock))
       );
 
     case isPut && strikePrice * maxPrice >= adjustedCollateral:

--- a/packages/front-end/src/hooks/useInitialData/index.tsx
+++ b/packages/front-end/src/hooks/useInitialData/index.tsx
@@ -79,7 +79,14 @@ export const useInitialData = () => {
       updatePriceData();
 
       getInitialData(data, address).then(
-        ([validExpiries, userPositions, chainData, isOperator, userVaults]) => {
+        ([
+          validExpiries,
+          userPositions,
+          chainData,
+          isOperator,
+          userVaults,
+          liquidationParameters,
+        ]) => {
           dispatch({
             type: ActionType.SET_OPTIONS,
             activeExpiry: activeExpiry || validExpiries[0],
@@ -89,6 +96,8 @@ export const useInitialData = () => {
             isOperator,
             loading,
             refresh,
+            spotShock: liquidationParameters.spotShock,
+            timesToExpiry: liquidationParameters.timesToExpiry,
             userPositions,
             vaults: userVaults,
           });

--- a/packages/front-end/src/hooks/useInitialData/utils.ts
+++ b/packages/front-end/src/hooks/useInitialData/utils.ts
@@ -293,8 +293,7 @@ const getLiquidationCalculationParameters = async () => {
     }
   };
 
-  try {
-    const parameters = await readContracts({
+   const parameters = await readContracts({
       contracts: [
         _getParams("USDC", "getSpotShock", true),
         _getParams("USDC", "getSpotShock", false),
@@ -329,38 +328,8 @@ const getLiquidationCalculationParameters = async () => {
         },
       },
     };
-  } catch (error) {
-    logError(error);
-
-    const defaultSpotShock = 0.7;
-    const defaultTimesToExpiry = [
-      604800, 1209600, 2419200, 3628800, 4838400, 6048000, 7257600,
-    ];
-
-    return {
-      spotShock: {
-        call: {
-          USDC: defaultSpotShock,
-          WETH: defaultSpotShock,
-        },
-        put: {
-          USDC: defaultSpotShock,
-          WETH: defaultSpotShock,
-        },
-      },
-      timesToExpiry: {
-        call: {
-          USDC: defaultTimesToExpiry,
-          WETH: defaultTimesToExpiry,
-        },
-        put: {
-          USDC: defaultTimesToExpiry,
-          WETH: defaultTimesToExpiry,
-        },
-      },
-    };
-  }
-};
+  };
+    
 
 export const getInitialData = async (
   data: InitialDataQuery,

--- a/packages/front-end/src/state/GlobalContext.tsx
+++ b/packages/front-end/src/state/GlobalContext.tsx
@@ -51,6 +51,26 @@ export const defaultGlobalState: GlobalState = {
     isOperator: false,
     loading: true,
     refresh: () => {},
+    spotShock: {
+      call: {
+        USDC: 0.7,
+        WETH: 0.7,
+      },
+      put: {
+        USDC: 0.7,
+        WETH: 0.7,
+      },
+    },
+    timesToExpiry: {
+      call: {
+        USDC: [604800, 1209600, 2419200, 3628800, 4838400, 6048000, 7257600],
+        WETH: [604800, 1209600, 2419200, 3628800, 4838400, 6048000, 7257600],
+      },
+      put: {
+        USDC: [604800, 1209600, 2419200, 3628800, 4838400, 6048000, 7257600],
+        WETH: [604800, 1209600, 2419200, 3628800, 4838400, 6048000, 7257600],
+      },
+    },
     userPositions: {},
     vaults: { length: 0 },
   },

--- a/packages/front-end/src/state/reducer.ts
+++ b/packages/front-end/src/state/reducer.ts
@@ -68,6 +68,8 @@ export const globalReducer: Reducer<GlobalState, GlobalAction> = (
           isOperator: action.isOperator ?? state.options.isOperator,
           loading: action.loading ?? state.options.loading,
           refresh: action.refresh || state.options.refresh,
+          spotShock: action.spotShock || state.options.spotShock,
+          timesToExpiry: action.timesToExpiry || state.options.timesToExpiry,
           userPositions: action.userPositions || state.options.userPositions,
           vaults: action.vaults || state.options.vaults,
         },

--- a/packages/front-end/src/state/types.ts
+++ b/packages/front-end/src/state/types.ts
@@ -40,6 +40,28 @@ export type PutSide = {
   put: StrikeSide;
 };
 
+export interface SpotShock {
+  call: {
+    USDC: number;
+    WETH: number;
+  };
+  put: {
+    USDC: number;
+    WETH: number;
+  };
+}
+
+export interface TimesToExpiry {
+  call: {
+    USDC: number[];
+    WETH: number[];
+  };
+  put: {
+    USDC: number[];
+    WETH: number[];
+  };
+}
+
 export type StrikeRangeTuple = [string, string];
 
 export type ColumNames =
@@ -102,6 +124,8 @@ export type GlobalState = {
     isOperator: boolean;
     loading: boolean;
     refresh: () => void;
+    spotShock: SpotShock;
+    timesToExpiry: TimesToExpiry;
     userPositions: UserPositions;
     vaults: UserVaults;
   };
@@ -185,6 +209,8 @@ export type GlobalAction =
       isOperator?: boolean;
       loading?: boolean;
       refresh?: () => void;
+      spotShock?: SpotShock;
+      timesToExpiry?: TimesToExpiry;
       userPositions?: UserPositions;
       vaults?: UserVaults;
     }

--- a/packages/front-end/src/utils/conversion-helper.ts
+++ b/packages/front-end/src/utils/conversion-helper.ts
@@ -43,6 +43,8 @@ export const fromOpynToNumber = (x: BigNumberish) => Number(fromOpyn(x));
 export const fromOpynNoDecimal = (x: BigNumberish) => fromOpyn(x).split(".")[0];
 export const fromRysk = (x: string) => utils.formatUnits(x, 18);
 export const fromRyskToNumber = (x: string) => Number(fromRysk(x));
+export const fromE27toInt = (value: BigNumberish) =>
+  parseFloat(utils.formatUnits(value, 27));
 export const getDiffSeconds = (now: Dayjs, future: Dayjs) =>
   future.unix() - now.unix();
 export const convertRounded = (x: BigNumberish): number =>


### PR DESCRIPTION
# Task: Calculate the liquidation price for selling.

## Description

- spotShock and timesToExpiry are now fetched on the initial load and stored in global state.
- Now displaying the liquidation price in USD terms for selling options.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [x] If appropriate, I have properly tested my new functionality
