### PR TITLE
Better buffers

### DIFF
--- a/packages/front-end/src/components/optionsTrading/Modals/BuyOptionModal/hooks/useBuyOption.tsx
+++ b/packages/front-end/src/components/optionsTrading/Modals/BuyOptionModal/hooks/useBuyOption.tsx
@@ -5,13 +5,13 @@ import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
+import { BigNumber } from "ethers";
 import { useGlobalContext } from "src/state/GlobalContext";
-import { toRysk, toUSDC, truncate } from "src/utils/conversion-helper";
+import { tFormatUSDC, toRysk, toUSDC } from "src/utils/conversion-helper";
 import { getContractAddress } from "src/utils/helpers";
 import { logError } from "src/utils/logError";
 import { useAllowance } from "../../Shared/hooks/useAllowance";
 import { getQuote } from "../../Shared/utils/getQuote";
-import { BigNumber } from "ethers";
 
 export const useBuyOption = (amountToBuy: string) => {
   // Global state.
@@ -68,7 +68,7 @@ export const useBuyOption = (amountToBuy: string) => {
           const remainingBalance =
             balances.USDC === 0 ? 0 : balances.USDC - quote;
 
-          const requiredApproval = String(truncate(quote * 1.05, 4));
+          const requiredApproval = String(tFormatUSDC(acceptablePremium, 4));
           const approved = toUSDC(requiredApproval).lte(allowance.amount);
 
           setPurchaseData({

--- a/packages/front-end/src/components/optionsTrading/Modals/CloseShortOptionModal/hooks/useShortPositionData.tsx
+++ b/packages/front-end/src/components/optionsTrading/Modals/CloseShortOptionModal/hooks/useShortPositionData.tsx
@@ -17,7 +17,6 @@ import {
   tFormatEth,
   tFormatUSDC,
   toRysk,
-  truncate,
 } from "src/utils/conversion-helper";
 import { getContractAddress } from "src/utils/helpers";
 import { logError } from "src/utils/logError";
@@ -141,7 +140,7 @@ export const useShortPositionData = (amountToClose: string) => {
             // Ensure user has sufficient wallet balance to cover premium before collateral is released.
             const hasRequiredCapital = balances.USDC > quote;
 
-            const requiredApproval = String(truncate(quote * 1.05, 4));
+            const requiredApproval = String(tFormatUSDC(acceptablePremium, 4));
             const approved = collateralToRemove.lte(allowance.amount);
 
             setPositionData({

--- a/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/hooks/useSellOption.tsx
+++ b/packages/front-end/src/components/optionsTrading/Modals/SellOptionModal/hooks/useSellOption.tsx
@@ -152,12 +152,15 @@ export const useSellOption = (amountToSell: string) => {
             ? balanceWETH
             : balanceWETH - collateral;
 
-          // Ensure user has sufficient wallet balance to cover collateral.
+          const approvalBuffer = 1.005;
+          // Ensure user has sufficient wallet balance to cover collateral + buffer.
           const hasRequiredCapital = USDCCollateral
-            ? balanceUSDC > collateral
-            : balanceWETH > collateral;
+            ? balanceUSDC > collateral * approvalBuffer
+            : balanceWETH > collateral * approvalBuffer;
 
-          const requiredApproval = String(truncate(collateral * 1.05, 4));
+          const requiredApproval = String(
+            truncate(collateral * approvalBuffer, 4)
+          );
           const approved = (
             USDCCollateral ? toUSDC(requiredApproval) : toRysk(requiredApproval)
           ).lte(allowance.amount);


### PR DESCRIPTION
# Task: Better approval buffers

## Description

- Now using the `acceptable premium` value as the approval buffer for longs and for closing shorts.
- The approval buffer for selling has been reduced from 5% to 0.5%.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [x] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [x] If appropriate, I have properly tested my new functionality
