### PR TITLE
Better transaction waiting

### DIFF
--- a/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/transactions.ts
+++ b/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/transactions.ts
@@ -30,6 +30,17 @@ import RyskActionType from "src/enums/RyskActionType";
 import { fromWeiToOpyn } from "src/utils/conversion-helper";
 import { getContractAddress } from "src/utils/helpers";
 
+const waitForTransactionOrTimer = async (
+  hash: HexString,
+  confirmations: number = 2,
+  timerMs: number = 15000
+) => {
+  return Promise.race([
+    waitForTransaction({ hash, confirmations }),
+    new Promise((resolve) => setTimeout(resolve, timerMs)),
+  ]);
+};
+
 export const approveAllowance = async (
   addresses: AddressesRequired,
   amount: BigNumberType
@@ -47,7 +58,7 @@ export const approveAllowance = async (
   if (config.request.data) {
     const { hash } = await writeContract(config);
 
-    await waitForTransaction({ hash, confirmations: 1 });
+    await waitForTransactionOrTimer(hash, 1);
 
     return hash;
   }
@@ -103,7 +114,7 @@ export const buy = async (
   if (config.request.data) {
     const { hash } = await writeContract(config);
 
-    await waitForTransaction({ hash, confirmations: 1 });
+    await waitForTransactionOrTimer(hash);
 
     refresh();
 
@@ -149,7 +160,7 @@ export const closeLong = async (
   if (config.request.data) {
     const { hash } = await writeContract(config);
 
-    await waitForTransaction({ hash, confirmations: 1 });
+    await waitForTransactionOrTimer(hash);
 
     refresh();
 
@@ -270,7 +281,7 @@ export const sell = async (
   if (config.request.data) {
     const { hash } = await writeContract(config);
 
-    await waitForTransaction({ hash, confirmations: 1 });
+    await waitForTransactionOrTimer(hash);
 
     refresh();
 
@@ -288,7 +299,7 @@ export const setOperator = async (isOperator: boolean) => {
 
   const { hash } = await writeContract(config);
 
-  await waitForTransaction({ hash, confirmations: 1 });
+  await waitForTransactionOrTimer(hash, 1);
 
   return hash;
 };
@@ -360,7 +371,7 @@ export const vaultSell = async (
   if (config.request.data) {
     const { hash } = await writeContract(config);
 
-    await waitForTransaction({ hash, confirmations: 1 });
+    await waitForTransactionOrTimer(hash);
 
     refresh();
 


### PR DESCRIPTION
# Task: Better transaction waiting

## Description

- Now using `Promise.race` to either wait for a specified amount of confirmations or a specified time in milliseconds, whichever comes first. This is designed to ensure that the graph (and thus the global state) has had a chance to update after a transaction and helps to avoid issues such as multiple vaults for the same oToken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [x] If appropriate, I have properly tested my new functionality
