### PR TITLE
Fix expected payout condition and graph 0.1.12

### DIFF
--- a/packages/front-end/.env.testnet
+++ b/packages/front-end/.env.testnet
@@ -2,5 +2,5 @@ REACT_APP_CHAIN_ID=421613
 REACT_APP_ENV="testnet"
 REACT_APP_NETWORK="arbitrum-goerli"
 REACT_APP_SCAN_URL="https://goerli.arbiscan.io"
-REACT_APP_SUBGRAPH_URL="https://api.goldsky.com/api/public/project_clhf7zaco0n9j490ce421agn4/subgraphs/devey/0.1.10/gn"
-# REACT_APP_SUBGRAPH_URL="https://api.studio.thegraph.com/query/45686/rysk/0.1.10"
+REACT_APP_SUBGRAPH_URL="https://api.goldsky.com/api/public/project_clhf7zaco0n9j490ce421agn4/subgraphs/devey/0.1.11/gn"
+# REACT_APP_SUBGRAPH_URL="https://api.studio.thegraph.com/query/45686/rysk/0.1.11"

--- a/packages/front-end/.env.testnet
+++ b/packages/front-end/.env.testnet
@@ -2,5 +2,5 @@ REACT_APP_CHAIN_ID=421613
 REACT_APP_ENV="testnet"
 REACT_APP_NETWORK="arbitrum-goerli"
 REACT_APP_SCAN_URL="https://goerli.arbiscan.io"
-REACT_APP_SUBGRAPH_URL="https://api.goldsky.com/api/public/project_clhf7zaco0n9j490ce421agn4/subgraphs/devey/0.1.11/gn"
-# REACT_APP_SUBGRAPH_URL="https://api.studio.thegraph.com/query/45686/rysk/0.1.11"
+REACT_APP_SUBGRAPH_URL="https://api.goldsky.com/api/public/project_clhf7zaco0n9j490ce421agn4/subgraphs/devey/0.1.12/gn"
+# REACT_APP_SUBGRAPH_URL="https://api.studio.thegraph.com/query/45686/rysk/0.1.12"

--- a/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
@@ -396,12 +396,13 @@ const usePositions = () => {
                   fee: 0,
                 };
 
-          const diff =
-            anyExpiredAction && isPut
+          const diff = anyExpiredAction
+            ? isPut
               ? Number(fromOpyn(strikePrice)) -
                 Number(fromOpyn(expiryPrice || 0))
               : Number(fromOpyn(expiryPrice || 0)) -
-                Number(fromOpyn(strikePrice));
+                Number(fromOpyn(strikePrice))
+            : 0;
           const expectedPayout =
             diff > 0 ? diff * Number(fromWei(netAmount)) : 0;
 

--- a/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
@@ -381,7 +381,7 @@ const usePositions = () => {
 
           // pnl
           const graphPnl = fromUSDC(realizedPnl);
-          const { acceptablePremium, fee } =
+          const { quote } =
             amount !== 0 && !anyExpiredAction
               ? await getQuote(
                   Number(expiryTimestamp),
@@ -392,8 +392,7 @@ const usePositions = () => {
                   collateralAssetSymbol
                 )
               : {
-                  acceptablePremium: 0,
-                  fee: 0,
+                  quote: 0,
                 };
 
           const diff = anyExpiredAction
@@ -429,14 +428,8 @@ const usePositions = () => {
               amount === 0
                 ? Number(graphPnl) // if closed position just use graph data
                 : vault.vaultId // short pnl is opposite of long as totPremium represents the earnings
-                ? Number(graphPnl) -
-                  (expectedPayout
-                    ? expectedPayout
-                    : Number(fromUSDC(acceptablePremium)) - fee)
-                : Number(graphPnl) +
-                  (expectedPayout
-                    ? expectedPayout
-                    : Number(fromUSDC(acceptablePremium)) - fee),
+                ? Number(graphPnl) - (expectedPayout ? expectedPayout : quote)
+                : Number(graphPnl) + (expectedPayout ? expectedPayout : quote),
             underlyingAsset: underlyingAsset.id,
           };
 


### PR DESCRIPTION
- The condition `anyExpiredAction && isPut` would still compute `expirePrice - strikePrice` but should just be 0.
- Update graph to 0.1.12 (fixes vault settled realised P/L)

# Pre-merge
- Need to update env vars for Vercel apps.
- Need to update env vars for graph failover.