### PR TITLE
Cancel old Hardhat runs

### DIFF
--- a/.github/workflows/hardhat.yml
+++ b/.github/workflows/hardhat.yml
@@ -1,11 +1,13 @@
 name: Hardhat
 
 on:
-  push:
+  pull_request:
     paths:
       - "packages/contracts/**"
       - "package.json"
       - ".github/workflows/hardhat.yml"
+
+  workflow_dispatch:
 
 defaults:
   run:
@@ -13,7 +15,9 @@ defaults:
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       ALCHEMY: ${{ secrets.ALCHEMY }}
       TEST_MNEMONIC: ${{ secrets.TEST_MNEMONIC }}
@@ -21,6 +25,11 @@ jobs:
       ARBITRUM_GOERLI: ${{ secrets.ARBITRUM_GOERLI }}
 
     steps:
+      - name: Cancel old runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# Task: Cancel old Hardhat runs

## Description

- Only kick-off actions when a PR is opened.
- Cancel old runs if new pushes are made before the previous run has ended.
- Set a 30-minute max run timeout.
- Add `workflow_dispatch` to allow for manual runs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
