### PR TITLE
Block collateral update if too close to liquidation

### DIFF
--- a/packages/front-end/src/components/dashboard/Modals/AdjustCollateralModal/index.tsx
+++ b/packages/front-end/src/components/dashboard/Modals/AdjustCollateralModal/index.tsx
@@ -29,6 +29,7 @@ import { Modal } from "src/components/optionsTrading/Modals/Shared/components/Mo
 import { useAllowance } from "src/components/optionsTrading/Modals/Shared/hooks/useAllowance";
 import { getLiquidationPrice } from "src/components/optionsTrading/Modals/Shared/utils/getLiquidationPrice";
 import { useDebouncedCallback } from "use-debounce";
+import { toast } from "react-toastify";
 
 const calculateNewCollateralAmount = (
   symbol: "USDC" | "WETH",
@@ -123,6 +124,20 @@ const AdjustCollateralModal = () => {
   };
 
   const handleCollateralUpdate = async () => {
+    if (
+      ethPrice &&
+      ((isPut && newLiquidationPrice > ethPrice) ||
+        (!isPut && newLiquidationPrice < ethPrice))
+    ) {
+      toast("❌ That's too much collateral to remove, transaction would fail.");
+      return;
+    }
+
+    if (ethPrice && Math.abs(newLiquidationPrice - ethPrice) < 50) {
+      toast("❌ Liquidation price is too close to current price of ETH.");
+      return;
+    }
+
     setTransactionPending(true);
 
     try {

--- a/packages/front-end/src/components/dashboard/Modals/AdjustCollateralModal/index.tsx
+++ b/packages/front-end/src/components/dashboard/Modals/AdjustCollateralModal/index.tsx
@@ -133,7 +133,7 @@ const AdjustCollateralModal = () => {
       return;
     }
 
-    if (ethPrice && Math.abs(newLiquidationPrice - ethPrice) < 50) {
+    if (ethPrice && Math.abs(newLiquidationPrice - ethPrice) < ethPrice * 0.1) {
       toast("❌ Liquidation price is too close to current price of ETH.");
       return;
     }

--- a/packages/front-end/src/components/dashboard/Modals/AdjustCollateralModal/index.tsx
+++ b/packages/front-end/src/components/dashboard/Modals/AdjustCollateralModal/index.tsx
@@ -133,7 +133,10 @@ const AdjustCollateralModal = () => {
       return;
     }
 
-    if (ethPrice && Math.abs(newLiquidationPrice - ethPrice) < ethPrice * 0.1) {
+    if (
+      ethPrice &&
+      Math.abs(newLiquidationPrice - ethPrice) < ethPrice * 0.03
+    ) {
       toast("❌ Liquidation price is too close to current price of ETH.");
       return;
     }


### PR DESCRIPTION
If the new liquidation price is less than 50 dollars away from the current underlying price then show a message and don't act.
If the new liquidation price is going to end in a failed transaction then show a message and don't act.