### PR TITLE
[RYSK-5] Use absolute value on net amount for expected payout

### DIFF
--- a/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
@@ -400,7 +400,7 @@ const usePositions = () => {
               : Number(fromOpyn(expiryPrice || 0)) - humanisedStrikePrice
             : 0;
           const expectedPayout =
-            diff > 0 ? diff * Number(fromWei(netAmount)) : 0;
+            diff > 0 ? diff * Math.abs(Number(fromWei(netAmount))) : 0;
 
           const premiumPerPosition = Math.abs(totPremiumUSDC) / humanisedAmount;
           const breakEven = isPut


### PR DESCRIPTION
Due to the fact that net amount of shorts is negative the multiplication for expected payout ends up being negative and P/L positive(` -(-x)`) which is incorrect as it adds to the realised P/L instead of, in case of shorts, removing.