### PR TITLE
Better dimming of chain row sides when untradeable

### DIFF
--- a/packages/front-end/src/components/optionsTrading/Chain/components/Body.tsx
+++ b/packages/front-end/src/components/optionsTrading/Chain/components/Body.tsx
@@ -115,7 +115,7 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
 
           return (
             <motion.tr
-              className={`group/row grid even:bg-bone odd:bg-bone-light bg-[url('./assets/wave-lines.png')] even:bg-[top_right_-50%] even:lg:bg-[top_right_-15%] even:xl:bg-[top_right_0%] odd:bg-[top_left_-80%] odd:lg:bg-[top_left_-40%] odd:xl:bg-[top_left_-20%] bg-no-repeat bg-contain text-right [&_td]:col-span-1 [&_td]:border [&_td]:border-dashed [&_td]:border-gray-500 [&_td]:ease-in-out [&_td]:duration-100 [&_td]:cursor-default [&_td]:text-2xs [&_td]:xl:text-sm ease-in-out duration-100 ${rowClasses} border-black border-dashed`}
+              className={`group/row grid even:bg-bone odd:bg-bone-light bg-[url('./assets/wave-lines.png')] even:bg-[top_right_-50%] even:lg:bg-[top_right_-15%] even:xl:bg-[top_right_0%] odd:bg-[top_left_-80%] odd:lg:bg-[top_left_-40%] odd:xl:bg-[top_left_-20%] bg-no-repeat bg-contain text-right [&_td]:col-span-1 [&_td]:border [&_td]:border-dashed [&_td]:border-gray-500 [&_td]:ease-in-out [&_td]:duration-100 [&_td]:text-2xs [&_td]:xl:text-sm ease-in-out duration-100 ${rowClasses} border-black border-dashed`}
               key={option.strike}
               style={{
                 gridTemplateColumns: `repeat(${colSize}, minmax(0, 1fr))`,
@@ -124,7 +124,7 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               layout="position"
             >
               {showCol("iv sell") && (
-                <Cell cellClasses="!border-l-0">
+                <Cell cellClasses="!border-l-0" disabled={callSellDisabled}>
                   <IV value={option.call.sell.IV} />
                 </Cell>
               )}
@@ -132,9 +132,10 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               <Cell
                 cellClasses={`${
                   callSellDisabled
-                    ? "text-gray-600 !bg-red-100/40"
+                    ? "!bg-red-100/40"
                     : "text-red-900 !bg-red-100/80"
                 } !p-0`}
+                disabled={callSellDisabled}
               >
                 <Quote
                   clickFn={setSelectedOption({
@@ -150,9 +151,10 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               <Cell
                 cellClasses={`${
                   callBuyDisabled
-                    ? "text-gray-600 !bg-green-100/20"
+                    ? "!bg-green-100/20"
                     : "text-green-1100 !bg-green-100/60"
                 } !p-0`}
+                disabled={callBuyDisabled}
               >
                 <Quote
                   clickFn={setSelectedOption({
@@ -166,20 +168,21 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               </Cell>
 
               {showCol("iv buy") && (
-                <Cell cellClasses="">
+                <Cell disabled={callBuyDisabled}>
                   <IV value={option.call.buy.IV} />
                 </Cell>
               )}
 
               {showCol("delta") && (
-                <Cell cellClasses="">
+                <Cell disabled={callSellDisabled && callBuyDisabled}>
                   <Delta value={option.call.delta} />
                 </Cell>
               )}
 
               {showCol("pos") && (
                 <Cell
-                  cellClasses={`${callPosDisabled ? "text-gray-600" : ""} !p-0`}
+                  cellClasses="!p-0"
+                  disabled={callSellDisabled && callBuyDisabled}
                 >
                   <Position
                     clickFn={() => {
@@ -197,7 +200,10 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               )}
 
               {showCol("exposure") && (
-                <Cell cellClasses="!border-r-0">
+                <Cell
+                  cellClasses="!border-r-0"
+                  disabled={callSellDisabled && callBuyDisabled}
+                >
                   <Exposure value={option.call.exposure} />
                 </Cell>
               )}
@@ -209,7 +215,7 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               />
 
               {showCol("iv sell") && (
-                <Cell cellClasses="!border-l-0 ">
+                <Cell cellClasses="!border-l-0" disabled={putSellDisabled}>
                   <IV value={option.put.sell.IV} />
                 </Cell>
               )}
@@ -217,9 +223,10 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               <Cell
                 cellClasses={`${
                   putSellDisabled
-                    ? "text-gray-600 !bg-red-100/40"
+                    ? "!bg-red-100/40"
                     : "text-red-900 !bg-red-100/80"
                 } !p-0`}
+                disabled={putSellDisabled}
               >
                 <Quote
                   clickFn={setSelectedOption({
@@ -235,9 +242,10 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               <Cell
                 cellClasses={`${
                   putBuyDisabled
-                    ? "text-gray-600 !bg-green-100/20"
+                    ? "!bg-green-100/20"
                     : "text-green-1100 !bg-green-100/60"
                 } !p-0`}
+                disabled={putBuyDisabled}
               >
                 <Quote
                   clickFn={setSelectedOption({
@@ -251,20 +259,21 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               </Cell>
 
               {showCol("iv buy") && (
-                <Cell cellClasses="">
+                <Cell disabled={putBuyDisabled}>
                   <IV value={option.put.buy.IV} />
                 </Cell>
               )}
 
               {showCol("delta") && (
-                <Cell cellClasses="">
+                <Cell disabled={putSellDisabled && putBuyDisabled}>
                   <Delta value={option.put.delta} />
                 </Cell>
               )}
 
               {showCol("pos") && (
                 <Cell
-                  cellClasses={`${putPosDisabled ? "text-gray-600" : ""} !p-0`}
+                  cellClasses="!p-0"
+                  disabled={putSellDisabled && putBuyDisabled}
                 >
                   <Position
                     clickFn={() => {
@@ -282,7 +291,10 @@ export const Body = ({ chainRows }: { chainRows: StrikeOptions[] }) => {
               )}
 
               {showCol("exposure") && (
-                <Cell cellClasses="!border-r-0">
+                <Cell
+                  cellClasses="!border-r-0"
+                  disabled={putSellDisabled && putBuyDisabled}
+                >
                   <Exposure value={option.put.exposure} />
                 </Cell>
               )}

--- a/packages/front-end/src/components/optionsTrading/Chain/components/Cells/index.tsx
+++ b/packages/front-end/src/components/optionsTrading/Chain/components/Cells/index.tsx
@@ -11,11 +11,13 @@ import type {
 import { RyskCountUp } from "src/components/shared/RyskCountUp";
 import { Triangle } from "src/Icons";
 
-export const Cell = ({ children, cellClasses }: CellProps) => {
+export const Cell = ({ children, cellClasses, disabled }: CellProps) => {
+  const disabledClasses = disabled
+    ? "text-gray-600 cursor-not-allowed group-hover/row:bg-inherit"
+    : "cursor-default group-hover/row:bg-green-100/50";
+
   return (
-    <td
-      className={`py-4 xl:py-2.5 px-1 group-hover/row:bg-green-100/50 ${cellClasses}`}
-    >
+    <td className={`py-4 xl:py-2.5 px-1 ${cellClasses} ${disabledClasses}`}>
       {children}
     </td>
   );

--- a/packages/front-end/src/components/optionsTrading/Chain/components/Cells/index.tsx
+++ b/packages/front-end/src/components/optionsTrading/Chain/components/Cells/index.tsx
@@ -13,7 +13,7 @@ import { Triangle } from "src/Icons";
 
 export const Cell = ({ children, cellClasses, disabled }: CellProps) => {
   const disabledClasses = disabled
-    ? "text-gray-600 cursor-not-allowed group-hover/row:bg-inherit"
+    ? "text-gray-500 cursor-not-allowed group-hover/row:bg-inherit"
     : "cursor-default group-hover/row:bg-green-100/50";
 
   return (

--- a/packages/front-end/src/components/optionsTrading/Chain/components/Cells/types.ts
+++ b/packages/front-end/src/components/optionsTrading/Chain/components/Cells/types.ts
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from "react";
 
 export interface CellProps extends PropsWithChildren {
   cellClasses?: string;
+  disabled: boolean;
 }
 
 interface BaseProps {


### PR DESCRIPTION
# Task: RYSK-25

## Description

For each strike side:
- Apply opacity to dim the whole row.
- Keep dim on hover.
- Change the cursor to not-allowed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
