### PR TITLE
[RYSK-9] Prefer WETH collateralised options for buys

### DIFF
--- a/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/transactions.ts
+++ b/packages/front-end/src/components/optionsTrading/Modals/Shared/utils/transactions.ts
@@ -71,33 +71,37 @@ export const buy = async (
   optionSeries: OptionSeries,
   refresh: () => void
 ) => {
+  const operations = [];
+
+  if (optionSeries.collateral !== getContractAddress("WETH"))
+    operations.push({
+      actionType: BigNumber.from(RyskActionType.Issue),
+      owner: ZERO_ADDRESS,
+      secondAddress: ZERO_ADDRESS,
+      asset: ZERO_ADDRESS,
+      vaultId: BigNumber.from(0),
+      amount: BigNumber.from(0),
+      optionSeries,
+      indexOrAcceptablePremium: BigNumber.from(0),
+      data: ZERO_ADDRESS,
+    });
+
+  operations.push({
+    actionType: BigNumber.from(RyskActionType.BuyOption),
+    owner: ZERO_ADDRESS,
+    secondAddress: addresses.user,
+    asset: ZERO_ADDRESS,
+    vaultId: BigNumber.from(0),
+    amount,
+    optionSeries,
+    indexOrAcceptablePremium: acceptablePremium,
+    data: ZERO_ADDRESS,
+  });
+
   const txData = [
     {
       operation: OperationType.RyskAction,
-      operationQueue: [
-        {
-          actionType: BigNumber.from(RyskActionType.Issue),
-          owner: ZERO_ADDRESS,
-          secondAddress: ZERO_ADDRESS,
-          asset: ZERO_ADDRESS,
-          vaultId: BigNumber.from(0),
-          amount: BigNumber.from(0),
-          optionSeries,
-          indexOrAcceptablePremium: BigNumber.from(0),
-          data: ZERO_ADDRESS,
-        },
-        {
-          actionType: BigNumber.from(RyskActionType.BuyOption),
-          owner: ZERO_ADDRESS,
-          secondAddress: addresses.user,
-          asset: ZERO_ADDRESS,
-          vaultId: BigNumber.from(0),
-          amount,
-          optionSeries,
-          indexOrAcceptablePremium: acceptablePremium,
-          data: ZERO_ADDRESS,
-        },
-      ],
+      operationQueue: operations,
     },
   ];
 


### PR DESCRIPTION
In case the `OptionExchange` has the version of the Option that uses `WETH` as collateral instead of `USDC` then give precedence to it as it reduces the total collateral locked by the protocol.