### PR TITLE
[RYSK-82] Fix empty positions labelling

### DIFF
--- a/packages/front-end/src/components/dashboard/OptionsTable/OptionsTable.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/OptionsTable.tsx
@@ -62,7 +62,7 @@ export const UserOptions = () => {
                   />
                 )}
 
-                {isConnected && activePositions.length && (
+                {isConnected && (
                   <>
                     {activePositions.length ? (
                       <Table
@@ -105,7 +105,7 @@ export const UserOptions = () => {
                   />
                 )}
 
-                {isConnected && inactivePositions.length && (
+                {isConnected && (
                   <>
                     {inactivePositions.length ? (
                       <Table


### PR DESCRIPTION
There are two `length` checks and the first one was incorrect as it would hide the whole component if `length` is zero.