### PR TITLE
[RYSK-82] Fix empty positions labelling

### DIFF
--- a/packages/front-end/src/components/dashboard/OptionsTable/OptionsTable.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/OptionsTable.tsx
@@ -23,7 +23,7 @@ export const UserOptions = () => {
 
   const [, setSearchParams] = useSearchParams();
 
-  const [loading, error] = usePositions();
+  const [status, error] = usePositions();
   const [completeRedeem] = useRedeem();
   const [completeSettle] = useSettle();
 
@@ -42,13 +42,15 @@ export const UserOptions = () => {
       tabs={[
         {
           label:
-            loading && !activePositions.length
+            status == "loading"
               ? "Loading Open..."
+              : status == "idle"
+              ? "Booting..."
               : "RYSK.Open",
           content: (
             <>
               <AnimatePresence initial={false} mode="wait">
-                {!activePositions.length && (loading || error) && (
+                {(status == "loading" || error) && (
                   <LoadingOrError
                     key="loading-or-error"
                     error={error}
@@ -62,7 +64,7 @@ export const UserOptions = () => {
                   />
                 )}
 
-                {isConnected && (
+                {isConnected && status == "success" && (
                   <>
                     {activePositions.length ? (
                       <Table
@@ -85,13 +87,15 @@ export const UserOptions = () => {
         },
         {
           label:
-            loading && !inactivePositions.length
+            status == "loading"
               ? "Loading Closed..."
+              : status == "idle"
+              ? "Booting..."
               : "RYSK.Closed",
           content: (
             <>
               <AnimatePresence initial={false} mode="wait">
-                {!inactivePositions.length && (loading || error) && (
+                {(status == "loading" || error) && (
                   <LoadingOrError
                     key="loading-or-error"
                     error={error}
@@ -105,7 +109,7 @@ export const UserOptions = () => {
                   />
                 )}
 
-                {isConnected && (
+                {isConnected && status == "success" && (
                   <>
                     {inactivePositions.length ? (
                       <Table

--- a/packages/front-end/src/components/dashboard/OptionsTable/OptionsTable.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/OptionsTable.tsx
@@ -41,12 +41,9 @@ export const UserOptions = () => {
       tabWidth={280}
       tabs={[
         {
-          label:
-            status == "loading"
-              ? "Loading Open..."
-              : status == "idle"
-              ? "Booting..."
-              : "RYSK.Open",
+          label: ["loading", "idle"].includes(status)
+            ? "Loading Open..."
+            : "RYSK.Open",
           content: (
             <>
               <AnimatePresence initial={false} mode="wait">
@@ -86,12 +83,9 @@ export const UserOptions = () => {
           ),
         },
         {
-          label:
-            status == "loading"
-              ? "Loading Closed..."
-              : status == "idle"
-              ? "Booting..."
-              : "RYSK.Closed",
+          label: ["loading", "idle"].includes(status)
+            ? "Loading Closed..."
+            : "RYSK.Closed",
           content: (
             <>
               <AnimatePresence initial={false} mode="wait">

--- a/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/hooks.tsx
@@ -57,7 +57,7 @@ const usePositions = () => {
     },
   } = useGlobalContext();
 
-  const [hookLoading, setHookLoading] = useState(false);
+  const [status, setStatus] = useState("idle");
 
   // NOTE: Only getting positions opened after redeploy of contracts
   const { error, data } = useQuery<{
@@ -180,7 +180,7 @@ const usePositions = () => {
 
     const constructPositionsData = async () => {
       if (Object.keys(chainData).length && data && allOracleAssets) {
-        setHookLoading(true);
+        setStatus("loading");
 
         const timeNow = dayjs().unix();
 
@@ -467,14 +467,14 @@ const usePositions = () => {
           inactivePositions: parsedInactivePositions,
         });
 
-        setHookLoading(false);
+        setStatus("success");
       }
     };
 
     constructPositionsData();
   }, [chainData, data, allOracleAssets, isDisconnected, ethPrice]);
 
-  return [hookLoading, error] as const;
+  return [status, error] as const;
 };
 
 /**


### PR DESCRIPTION
Use a `status` string to identify `idle`, `loading` and `success` stages to avoid UI mislabeling.