### PR TITLE
[RYSK-6] Hide collateral label on inactive positions

### DIFF
--- a/packages/front-end/src/components/dashboard/OptionsTable/components/Table.tsx
+++ b/packages/front-end/src/components/dashboard/OptionsTable/components/Table.tsx
@@ -197,7 +197,9 @@ const Table = ({
               />
               <NumberFormat
                 value={
-                  collateralAsset
+                  // 1. If no collateral asset --> either a long or inactive short
+                  // 2. Inactive short can have collateralAsset true if position vault has collateral leftover
+                  collateralAsset && amount != 0
                     ? {
                         USDC: fromUSDC(collateralAmount),
                         "Wrapped Ether": fromWei(collateralAmount),


### PR DESCRIPTION
There can be residuals of collateral in the vault associated with the position, even after closed, and in that case `collateralAsset: string` will not be set to `null` on graph and FE will keep showing the label.

Checking for position zero solves it as that means that it's either been closed or settled and in both of these cases there shouldn't be any worthy amount in the vault.