### PR TITLE
Vercel Bash Script

### DIFF
--- a/packages/front-end/vercel-deployment.sh
+++ b/packages/front-end/vercel-deployment.sh
@@ -1,0 +1,9 @@
+if [ "$VERCEL_ENV" == "production" ];
+then
+  exit 1; 
+elif [ -v $(git diff HEAD~3 HEAD --quiet ./packages/front-end) ];
+then
+  exit 1; 
+else
+  exit 0;
+fi


### PR DESCRIPTION
Makes use of new build step settings in Vercel.

If Vercel env is prod, always build.
If Vercel env is not prod, only build if files in `front-end` have changed recently.