### PR TITLE
Vault performance chart improvements

### DIFF
--- a/packages/front-end/src/components/VaultPerformance/README.md
+++ b/packages/front-end/src/components/VaultPerformance/README.md
@@ -1,5 +1,5 @@
 # Vault performance chart component
 
-The vault performance chart is made up of a series of subcomponents with a single graph query at the top. This query accesses the `pricePerShares` graph data, skipping the first two entries. This is because the first two epochs were used for testing and pre-public launch.
+The vault performance chart is made up of a series of subcomponents with a single graph query at the top. This query accesses the `pricePerShares` graph data, skipping the first two entries. This is because the first three epochs were used for testing and pre-public launch.
 
-An effect in the main `VaultPerformance` component handles adjusting each of the epoch nodes by deducting the growth percentage at the third epoch from each subsequent epoch. This allows us to display chart data from the public launch, corrected as if the third epoch were zero percent.
+An effect in the main `VaultPerformance` component handles adjusting each of the epoch nodes by deducting the growth percentage at the fourth epoch from each subsequent epoch. This allows us to display chart data from the public launch, corrected as if the fourth epoch were zero percent.

--- a/packages/front-end/src/components/VaultPerformance/VaultPerformance.tsx
+++ b/packages/front-end/src/components/VaultPerformance/VaultPerformance.tsx
@@ -25,7 +25,7 @@ export const VaultPerformance = () => {
           orderBy: "epoch"
           orderDirection: "asc"
           first: 1000
-          skip: 2
+          skip: 3
         ) {
           epoch
           growthSinceFirstEpoch

--- a/packages/front-end/src/components/VaultPerformance/VaultPerformance.tsx
+++ b/packages/front-end/src/components/VaultPerformance/VaultPerformance.tsx
@@ -78,13 +78,14 @@ export const VaultPerformance = () => {
 
       {data && (
         <FadeWrapper key="data">
-          <Stats
-            cumulativeYield={
-              chartData[chartData.length - 1]?.growthSinceFirstEpoch
-            }
-          />
-          <Chart chartData={chartData} />
-          <Disclaimer />
+          <section className="flex flex-col w-1/4 xl:1/3">
+            <Stats chartData={chartData} />
+            <Disclaimer />
+          </section>
+
+          <section className="w-3/4 xl:2/3">
+            <Chart chartData={chartData} />
+          </section>
         </FadeWrapper>
       )}
     </AnimatePresence>

--- a/packages/front-end/src/components/VaultPerformance/VaultPerformance.types.ts
+++ b/packages/front-end/src/components/VaultPerformance/VaultPerformance.types.ts
@@ -20,7 +20,7 @@ export interface CustomTooltipProps {
     {
       value: string;
       payload: { epoch: string };
-    }
+    },
   ];
   label?: string;
 }

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/Chart.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/Chart.tsx
@@ -4,24 +4,22 @@ import dayjs from "dayjs";
 import {
   LineChart,
   Line,
-  CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   ResponsiveContainer,
-  Legend,
 } from "recharts";
 
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (label && active && payload && payload.length) {
     return (
-      <div
-        className="custom-tooltip bg-bone bg-opacity-90 border-black p-4 border-2 rounded-xl"
-        role="dialog"
-      >
-        <p>{dayjs.unix(parseInt(label)).format("DD MMM YY")}</p>
-        <p className="label">{`Yield: ${payload[0].value}%`}</p>
-        <p className="label">{`Epoch: ${payload[0].payload.epoch}`}</p>
+      <div className="bg-white rounded-lg shadow-lg font-dm-mono text-center">
+        <p className="px-4 pt-4 pb-2 border-b-2 border-bone text-xl font-medium after:content-['_%']">
+          {payload[0].value}
+        </p>
+        <p className="p-2 text-sm">
+          {dayjs.unix(parseInt(label)).format("DD MMM YY")}
+        </p>
       </div>
     );
   }
@@ -30,24 +28,20 @@ const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
 };
 
 export const Chart = ({ chartData }: ChartProps) => (
-  <div
-    className="p-8 flex flex-col lg:flex-row h-full justify-around"
-    role="graphics-document"
-  >
-    <ResponsiveContainer width={"100%"} height={400} className="">
-      <LineChart
-        data={chartData}
-        margin={{ top: 5, right: 40, bottom: 5, left: 20 }}
-      >
+  <div className="p-8" role="graphics-document">
+    <ResponsiveContainer width={"100%"} height={384}>
+      <LineChart data={chartData}>
         <Line
-          type="natural"
+          activeDot={{ fill: "#00FEFD", stroke: "#00FEFD" }}
           dataKey="growthSinceFirstEpoch"
-          // TODO access color through Tailwind helpers
+          dot={{ r: 4, fill: "black", stroke: "black" }}
           stroke="black"
           strokeWidth={2}
+          type="linear"
         />
-        <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
         <XAxis
+          stroke="black"
+          strokeWidth={2}
           type="number"
           scale="time"
           domain={["dataMin", "dataMax"]}
@@ -57,13 +51,15 @@ export const Chart = ({ chartData }: ChartProps) => (
           tickFormatter={(value: string) =>
             dayjs.unix(parseInt(value)).format("DD MMM")
           }
+          padding={{ left: 16, right: 16 }}
         />
         <YAxis
+          stroke="black"
+          strokeWidth={2}
           padding={{ top: 16, bottom: 16 }}
           tickFormatter={(value: string) => `${value}%`}
         />
-        <Tooltip content={<CustomTooltip />} />
-        <Legend verticalAlign="bottom" formatter={() => "Returns"} />
+        <Tooltip content={<CustomTooltip />} cursor={false} />
       </LineChart>
     </ResponsiveContainer>
   </div>

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/Disclaimer.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/Disclaimer.tsx
@@ -2,9 +2,14 @@ import { DHV_NAME } from "src/config/constants";
 import { DISCORD_LINK } from "src/config/links";
 
 export const Disclaimer = () => (
-  <small className="pb-8 px-8 block mx-[20%]">
-    {`This chart shows the ${DHV_NAME} share price change since the third epoch (public launch). Data before this is the result of testing and is excluded. If you have any questions, feel free to `}
-    <a href={DISCORD_LINK} target="_blank" rel="noopener noreferrer">
+  <small className="block mt-auto pl-8 pb-16 text-justify text-2xs xl:text-sm">
+    {`This chart shows the ${DHV_NAME} share price change since the fourth epoch (public launch). Data before this is the result of testing and is excluded. If you have any questions, feel free to `}
+    <a
+      className="!text-cyan-dark-compliant underline"
+      href={DISCORD_LINK}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {`reach out to us via our Discord.`}
     </a>
   </small>

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/Error.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/Error.tsx
@@ -1,3 +1,3 @@
 export const Error = () => (
-  <p className="p-8 pt-12 text-center">{`Sorry but we're having difficult fetching that data right now. Please try again later.`}</p>
+  <p className="p-8 pt-12 text-center w-full">{`Sorry but we're having difficult fetching that data right now. Please try again later.`}</p>
 );

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/FadeWrapper.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/FadeWrapper.tsx
@@ -12,5 +12,7 @@ const FadeInOut = {
 };
 
 export const FadeWrapper = ({ children }: PropsWithChildren<unknown>) => (
-  <motion.div {...FadeInOut}>{children}</motion.div>
+  <motion.div className="flex" {...FadeInOut}>
+    {children}
+  </motion.div>
 );

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/Loading.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/Loading.tsx
@@ -1,7 +1,7 @@
 import { Loader } from "src/components/Loader";
 
 export const Loading = () => (
-  <div className="p-8 pt-12">
+  <div className="p-8 pt-12 w-full">
     <Loader className="mx-auto h-16" />
   </div>
 );

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/Stats.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/Stats.tsx
@@ -1,6 +1,48 @@
-export const Stats = ({ cumulativeYield = 0 }: { cumulativeYield: number }) => (
-  <div className="pb-8 py-12 px-8 flex flex-col lg:flex-row h-full justify-around">
-    <h4 className="mb-2 text-xl">{`Historical Returns: ${cumulativeYield}%`}</h4>
-    <h4 className="mb-2 text-xl">{`Annualized Returns: Soon™️`}</h4>
-  </div>
-);
+import type { ChartData } from "../VaultPerformance.types";
+
+import { RyskCountUp } from "src/components/shared/RyskCountUp";
+import {
+  SECONDS_IN_YEAR,
+  SECOND_IN_THIRTY_DAYS,
+} from "src/utils/conversion-helper";
+import { toTwoDecimalPlaces } from "src/utils/rounding";
+
+export const Stats = ({ chartData }: { chartData: ChartData[] }) => {
+  if (!chartData.length) return null;
+
+  const firstEpoch = chartData[0];
+  const latestEpoch = chartData[chartData.length - 1];
+  const totalEpochTime =
+    parseInt(latestEpoch.timestamp) - parseInt(firstEpoch.timestamp);
+
+  const historicalReturns = latestEpoch?.growthSinceFirstEpoch;
+  const showAnnualisedReturns = totalEpochTime >= SECOND_IN_THIRTY_DAYS;
+  const annualisedReturns = toTwoDecimalPlaces(
+    (Math.pow(1 + historicalReturns / 100, SECONDS_IN_YEAR / totalEpochTime) -
+      1) *
+      100
+  );
+
+  return (
+    <div className="flex flex-col py-8 pl-8 justify-around">
+      <p className="text-sm xl:text-xl mb-2">{`Historical Returns`}</p>
+      <p className="after:content-['_%'] mb-8 font-dm-mono text-xl xl:text-2xl text-green-1100">
+        <RyskCountUp value={historicalReturns} />
+      </p>
+
+      {showAnnualisedReturns ? (
+        <>
+          <p className="text-sm xl:text-xl mb-2">{`Annualised Returns`}</p>
+          <p className="after:content-['_%'] font-dm-mono text-xl xl:text-2xl text-green-1100">
+            <RyskCountUp value={annualisedReturns} />
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm xl:text-xl mb-2">{`Annualised Returns`}</p>
+          <p className="text-xl xl:text-2xl">{`Soon™`}</p>
+        </>
+      )}
+    </div>
+  );
+};

--- a/packages/front-end/src/components/vault/VaultContent.tsx
+++ b/packages/front-end/src/components/vault/VaultContent.tsx
@@ -109,6 +109,7 @@ export const VaultContent = () => {
 
       <section className="col-start-1 col-end-17 mt-16">
         <Card
+          initialTabIndex={2}
           tabs={[
             {
               label: "Overview",

--- a/packages/front-end/src/utils/conversion-helper.ts
+++ b/packages/front-end/src/utils/conversion-helper.ts
@@ -16,6 +16,7 @@ export const MAX_BPS = BigNumber.from(10000);
 export const CALL = false;
 export const PUT = true;
 export const SECONDS_IN_DAY = 86400;
+export const SECOND_IN_THIRTY_DAYS = SECONDS_IN_DAY * 30;
 export const SECONDS_IN_YEAR = SECONDS_IN_DAY * 365.25;
 export const genOptionTime = (now: Dayjs, future: Dayjs) =>
   (future.unix() - now.unix()) / SECONDS_IN_YEAR;
@@ -77,7 +78,7 @@ export type BlackScholesCalcArgs = [
   BigNumberish,
   BigNumberish,
   BigNumberish,
-  BigNumberish
+  BigNumberish,
 ];
 const sum = function (array: [number]) {
   let total = 0;


### PR DESCRIPTION
# Task: RYSK-337

## Description

- Now showing annualised return once 30 days have passed.
- UI updates to bring layout/chart more aligned with branding guidelines.
- Now defaulting to the performance tab.
- Now skipping the first 3 epochs instead of 2.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [x] If appropriate, I have properly tested my new functionality
