### PR TITLE
Add hard coded ETH performance to chart.

### DIFF
--- a/packages/front-end/src/components/VaultPerformance/VaultPerformance.tsx
+++ b/packages/front-end/src/components/VaultPerformance/VaultPerformance.tsx
@@ -46,7 +46,10 @@ export const VaultPerformance = () => {
         ? parseFloat(pricePerShares[0].growthSinceFirstEpoch)
         : 0;
 
-      const adjustedChartData = pricePerShares.map((pricePoint) => {
+      // Values need replacing with API/Chain data.
+      const ethPrices = [1892.21, 1877.3, 1845.48, 1842.73, 1653.45];
+
+      const adjustedChartData = pricePerShares.map((pricePoint, index) => {
         const pricePointGrowth = parseFloat(pricePoint.growthSinceFirstEpoch);
         const growthSinceFirstEpoch = toTwoDecimalPlaces(
           pricePointGrowth - publicLaunchOffset
@@ -54,6 +57,9 @@ export const VaultPerformance = () => {
 
         return {
           ...pricePoint,
+          ethPrice: toTwoDecimalPlaces(
+            (ethPrices[index] / ethPrices[0] - 1) * 100
+          ),
           growthSinceFirstEpoch,
         };
       });

--- a/packages/front-end/src/components/VaultPerformance/VaultPerformance.types.ts
+++ b/packages/front-end/src/components/VaultPerformance/VaultPerformance.types.ts
@@ -21,6 +21,10 @@ export interface CustomTooltipProps {
       value: string;
       payload: { epoch: string };
     },
+    {
+      value: string;
+      payload: { epoch: string };
+    },
   ];
   label?: string;
 }

--- a/packages/front-end/src/components/VaultPerformance/subcomponents/Chart.tsx
+++ b/packages/front-end/src/components/VaultPerformance/subcomponents/Chart.tsx
@@ -8,14 +8,20 @@ import {
   YAxis,
   Tooltip,
   ResponsiveContainer,
+  Legend,
 } from "recharts";
 
 const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (label && active && payload && payload.length) {
+    const [dhv, eth] = payload;
+
     return (
-      <div className="bg-white rounded-lg shadow-lg font-dm-mono text-center">
-        <p className="px-4 pt-4 pb-2 border-b-2 border-bone text-xl font-medium after:content-['_%']">
-          {payload[0].value}
+      <div className="bg-white rounded-lg shadow-lg font-dm-mono text-center w-60">
+        <p className="px-4 pt-4 pb-2 text-xl font-medium after:content-['_%']">
+          {`DHV: ${dhv.value}`}
+        </p>
+        <p className="px-4 pb-2 border-b-2 border-bone text-xl font-medium after:content-['_%']">
+          {`ETH: ${eth.value}`}
         </p>
         <p className="p-2 text-sm">
           {dayjs.unix(parseInt(label)).format("DD MMM YY")}
@@ -35,7 +41,17 @@ export const Chart = ({ chartData }: ChartProps) => (
           activeDot={{ fill: "#00FEFD", stroke: "#00FEFD" }}
           dataKey="growthSinceFirstEpoch"
           dot={{ r: 4, fill: "black", stroke: "black" }}
+          name="DHV"
           stroke="black"
+          strokeWidth={2}
+          type="linear"
+        />
+        <Line
+          activeDot={{ fill: "#343434", stroke: "#343434" }}
+          dataKey="ethPrice"
+          dot={{ r: 4, fill: "#626890", stroke: "#626890" }}
+          name="Ethereum"
+          stroke="#626890"
           strokeWidth={2}
           type="linear"
         />
@@ -60,6 +76,7 @@ export const Chart = ({ chartData }: ChartProps) => (
           tickFormatter={(value: string) => `${value}%`}
         />
         <Tooltip content={<CustomTooltip />} cursor={false} />
+        <Legend iconType="circle" />
       </LineChart>
     </ResponsiveContainer>
   </div>


### PR DESCRIPTION
# Task: RYSK-352

## Description

- Adds ETH price to the performance chart.
- Using hard-coded values for speed. I will re-use the ticket to make it dynamic for the future.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
