### PR TITLE
add exitActiveRangeOrder to manager

### DIFF
--- a/packages/contracts/contracts/interfaces/IRangeOrderReactor.sol
+++ b/packages/contracts/contracts/interfaces/IRangeOrderReactor.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0;
+
+import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+
+/// @title Functionality unique to range order reactor outside of IHedging Reactor.
+
+struct Position {
+    int24 activeLowerTick; // uniswap v3 pool lower tick spacing - set to 0 if no active range order
+    int24 activeUpperTick; // uniswap v3 pool upper tick spacing - set to 0 if no active range order
+    bool activeRangeAboveTick; // set to true if target is above tick at time of init position
+}
+
+interface IRangeOrderReactor {
+
+    function pool() external view returns (IUniswapV3Pool);
+    function currentPosition() external view returns (Position memory);
+    function exitActiveRangeOrder() external;
+
+    //function createUniswapRangeOrder(RangeOrderParams calldata params, uint256 amountDesired) external;
+
+}

--- a/packages/contracts/contracts/interfaces/IRangeOrderReactor.sol
+++ b/packages/contracts/contracts/interfaces/IRangeOrderReactor.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.0;
 
-import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
-
 /// @title Functionality unique to range order reactor outside of IHedging Reactor.
 
 struct Position {
@@ -11,9 +9,21 @@ struct Position {
     bool activeRangeAboveTick; // set to true if target is above tick at time of init position
 }
 
+// truncating slot0 to prevent stack too deep error
+// We only require tick
+interface IUniswapV3PoolState {
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick
+        );
+}
+
 interface IRangeOrderReactor {
 
-    function pool() external view returns (IUniswapV3Pool);
+    function pool() external view returns (IUniswapV3PoolState);
     function currentPosition() external view returns (Position memory);
     function exitActiveRangeOrder() external;
 


### PR DESCRIPTION
# Task: RYSK-?

## Description

This is a proposed change to the manager contract that would allow active range orders to be exited before they are fulfilled.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
- [ ] Quality of life improvement
- [ ] Package upgrades

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have NATSPEC'd any new functions
- [ ] If appropriate, I have properly tested my new functionality
